### PR TITLE
feat: add comprehensive WebSocket benchmark automation and new frameworks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,27 +2,32 @@ benchmark-scenarios:
 	k6 run ./benchmarks/scenarios.js
 
 benchmark-connection:
-	k6 run --vus 128 --duration 5s ./benchmarks/connection.js > ./results/connection.txt
+	k6 run --vus 16 --duration 5s ./benchmarks/connection.js > ./results/connection.txt
 
 benchmark-plain-async:
-	k6 run --vus 128 --duration 5s ./benchmarks/plain-async.js > ./results/plain-async.txt
+	k6 run --vus 16 --duration 5s ./benchmarks/plain-async.js > ./results/plain-async.txt
 
 benchmark-plain-sync:
-	k6 run --vus 128 --duration 5s ./benchmarks/plain-sync.js > ./results/plain-sync.txt
+	k6 run --vus 16 --duration 5s ./benchmarks/plain-sync.js > ./results/plain-sync.txt
 
 benchmark-json-async:
-	k6 run --vus 128 --duration 5s ./benchmarks/json-async.js > ./results/json-async.txt
+	k6 run --vus 16 --duration 5s ./benchmarks/json-async.js > ./results/json-async.txt
 
 benchmark-json-sync:
-	k6 run --vus 128 --duration 5s ./benchmarks/json-sync.js > ./results/json-sync.txt
+	k6 run --vus 16 --duration 5s ./benchmarks/json-sync.js > ./results/json-sync.txt
 
 benchmark-binary-async:
-	k6 run --vus 128 --duration 5s ./benchmarks/binary-async.js > ./results/binary-async.txt
+	k6 run --vus 16 --duration 5s ./benchmarks/binary-async.js > ./results/binary-async.txt
 
 benchmark-binary-sync:
-	k6 run --vus 128 --duration 5s ./benchmarks/binary-sync.js > ./results/binary-sync.txt
+	k6 run --vus 16 --duration 5s ./benchmarks/binary-sync.js > ./results/binary-sync.txt
 
-benchmark-all: \
+benchmark-all:
+	@echo "Running comprehensive benchmarks for all frameworks..."
+	@chmod +x websocket_benchmark.sh
+	./websocket_benchmark.sh benchmark
+
+benchmark-individual: \
 	benchmark-connection \
 	benchmark-plain-async \
 	benchmark-plain-sync \
@@ -30,3 +35,13 @@ benchmark-all: \
 	benchmark-json-sync \
 	benchmark-binary-async \
 	benchmark-binary-sync
+
+extract-results:
+	@echo "Extracting benchmark results..."
+	@chmod +x websocket_benchmark.sh
+	./websocket_benchmark.sh extract
+
+benchmark-comprehensive:
+	@echo "Running comprehensive WebSocket benchmark suite..."
+	@chmod +x websocket_benchmark.sh
+	./websocket_benchmark.sh both

--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@ This repository compares the speed of WebSocket frameworks for different languag
 3. [gorilla/websocket](https://github.com/gorilla/websocket)
 4. [fasthttp/websocket](https://github.com/fasthttp/websocket)
 5. [tokio-tungstenite](https://github.com/snapview/tokio-tungstenite)
+6. [websocketpp](https://github.com/zaphoyd/websocketpp)
+7. [sip](https://github.com/PooyaEimandar/sib) Thanks to @PooyaEimandar
 
 ## Test Resources
 
 To ensure a fair comparison, the resources will be limited using Docker to determine the most efficient framework per resource.
 
-CPU Limit: 4 cores
+CPU Limit: 2 cores (Apply M3)
 
 Memory Limit: 1GB
 
@@ -30,7 +32,7 @@ More details: <https://docs.docker.com/config/containers/resource_constraints/>
 
 Port Number: 9001
 
-All tests are performed in concurrent connections using 64 and 128 virtual users (VUs) with a duration of 5 seconds for each test.
+All tests are performed in concurrent connections using 16, 64, 128 virtual users (VUs) with a duration of 5 seconds for each test.
 
 1. Connection Speed Test
 
@@ -78,15 +80,75 @@ In real use cases, we don't only receive and send messages using frameworks. Oth
 
 Check other results in the `./results` directory.
 
+### Connection Method 16 VUs Result
+
+| Framework          | ws_sessions   | ws_connecting                                                             |
+| ------------------ | ------------- | ------------------------------------------------------------------------- |
+| bun-websocket      | 8499.867364/s | avg=1.84ms min=499.66µs med=1.65ms max=58.16ms p(90)=2.43ms p(95)=2.8ms   |
+| fasthttp-websocket | 8412.220813/s | avg=1.86ms min=311.83µs med=1.69ms max=34.66ms p(90)=2.52ms p(95)=2.94ms  |
+| tokio-tungstenite  | 8001.300394/s | avg=1.96ms min=476.37µs med=1.76ms max=55.22ms p(90)=2.59ms p(95)=3ms     |
+| uwebsocket-js      | 7794.733031/s | avg=2ms min=482.7µs med=1.79ms max=103.02ms p(90)=2.63ms p(95)=3.06ms     |
+| websocketpp        | 6494.632196/s | avg=2.42ms min=625µs med=2.22ms max=65.99ms p(90)=2.96ms p(95)=3.38ms     |
+| gorilla-websocket  | 4041.91578/s  | avg=3.91ms min=362.91µs med=1.96ms max=202.4ms p(90)=9.77ms p(95)=12.61ms |
+| sib                | 13.398208/s   | avg=747.03ms min=265.54µs med=1.62ms max=34.93s p(90)=4.51ms p(95)=5.66ms |
+
+### JSON Sync Method 16 VUs Result
+
+| Framework          | ws_msgs_received |
+| ------------------ | ---------------- |
+| tokio-tungstenite  | 37935.617767/s   |
+| bun-websocket      | 36708.43469/s    |
+| gorilla-websocket  | 34822.879647/s   |
+| websocketpp        | 34657.213957/s   |
+| fasthttp-websocket | 32446.244966/s   |
+| uwebsocket-js      | 32044.007075/s   |
+| sib                | 28158.671323/s   |
+
+### JSON Async Method 16 VUs Result
+
+| Framework          | ws_msgs_received |
+| ------------------ | ---------------- |
+| tokio-tungstenite  | 327224.988122/s  |
+| bun-websocket      | 293216.98072/s   |
+| websocketpp        | 291755.287335/s  |
+| uwebsocket-js      | 266258.581015/s  |
+| fasthttp-websocket | 209233.336363/s  |
+| gorilla-websocket  | 201350.128115/s  |
+| sib                | 37153.030704/s   |
+
+### Binary Sync Method 16 VUs Result
+
+| Framework          | ws_msgs_received |
+| ------------------ | ---------------- |
+| tokio-tungstenite  | 37347.855585/s   |
+| websocketpp        | 36198.696847/s   |
+| uwebsocket-js      | 34129.443009/s   |
+| gorilla-websocket  | 34065.377308/s   |
+| bun-websocket      | 34028.915716/s   |
+| fasthttp-websocket | 30066.910145/s   |
+| sib                | 28952.664725/s   |
+
+### Binary Async Method 16 VUs Result
+
+| Framework          | ws_msgs_received |
+| ------------------ | ---------------- |
+| tokio-tungstenite  | 297233.517612/s  |
+| sib                | 292559.60582/s   |
+| websocketpp        | 274422.674722/s  |
+| gorilla-websocket  | 262322.002225/s  |
+| bun-websocket      | 239248.186499/s  |
+| fasthttp-websocket | 234948.363489/s  |
+| uwebsocket-js      | 134965.345539/s  |
+
 ### Connection Method 64 VUS Result
 
-| framework          | ws_sessions    | ws_connecting                                   |
-| ------------------ | -------------- | ----------------------------------------------- |
-| tokio-tungstenite  | 13137.162324/s | avg=4.77ms min=551.53µs med=4.44ms max=80.03ms  |
-| bun-websocket      | 13069.55048/s  | avg=4.79ms min=525.68µs med=4.39ms max=100.63ms |
-| uwebsocket-js      | 11882.529466/s | avg=5.27ms min=682.24µs med=4.81ms max=58.78ms  |
-| fasthttp-websocket | 11524.364692/s | avg=5.44ms min=475.44µs med=4.94ms max=82.83ms  |
-| gorilla-websocket  | 10754.352134/s | avg=5.83ms min=621.41µs med=5.28ms max=75.57ms  |
+| framework          | ws_sessions    | ws_connecting                                                             |
+| ------------------ | -------------- | ------------------------------------------------------------------------- |
+| tokio-tungstenite  | 13137.162324/s | avg=4.77ms min=551.53µs med=4.44ms max=80.03ms p(90)=6.78ms p(95)=7.72ms  |
+| bun-websocket      | 13069.55048/s  | avg=4.79ms min=525.68µs med=4.39ms max=100.63ms p(90)=6.87ms p(95)=7.97ms |
+| uwebsocket-js      | 11882.529466/s | avg=5.27ms min=682.24µs med=4.81ms max=58.78ms p(90)=7.58ms p(95)=8.8ms   |
+| fasthttp-websocket | 11524.364692/s | avg=5.44ms min=475.44µs med=4.94ms max=82.83ms p(90)=8.3ms p(95)=9.7ms    |
+| gorilla-websocket  | 10754.352134/s | avg=5.83ms min=621.41µs med=5.28ms max=75.57ms p(90)=8.87ms p(95)=10.48ms |
 
 ### JSON Sync Method 64 VUS Result
 
@@ -102,19 +164,19 @@ Check other results in the `./results` directory.
 
 | framework          | ws_msgs_received |
 | ------------------ | ---------------- |
-| tokio-tungstenite  | 442561.993299/s  |
 | bun-websocket      | 611168.371646/s  |
 | uwebsocket-js      | 563460.469109/s  |
 | fasthttp-websocket | 508246.997076/s  |
 | gorilla-websocket  | 498667.980764/s  |
+| tokio-tungstenite  | 442561.993299/s  |
 
 ### Binary Sync Method 64 VUS Result
 
 | framework          | ws_msgs_received |
 | ------------------ | ---------------- |
 | tokio-tungstenite  | 80498.928468/s   |
-| bun-websocket      | 69794.434565/s   |
 | uwebsocket-js      | 75384.902691/s   |
+| bun-websocket      | 69794.434565/s   |
 | fasthttp-websocket | 68214.604466/s   |
 | gorilla-websocket  | 67583.49342/s    |
 
@@ -127,33 +189,6 @@ Check other results in the `./results` directory.
 | uwebsocket-js      | 451046.522207/s  |
 | fasthttp-websocket | 440250.603802/s  |
 | gorilla-websocket  | 434406.944224/s  |
-
-### Connection Method 128 VUS Result
-
-| framework          | ws_sessions    | ws_connecting                                    |
-| ------------------ | -------------- | ------------------------------------------------ |
-| tokio-tungstenite  | 10270.04948/s  | avg=12.22ms min=927.69µs med=11.39ms max=143.9ms |
-| bun-websocket      | 14545.719639/s | avg=8.65ms min=829.85µs med=7.89ms max=116.45ms  |
-| uwebsocket-js      | 14264.117417/s | avg=8.78ms min=489.82µs med=7.89ms max=160.06ms  |
-| fasthttp-websocket | 12807.055832/s | avg=9.78ms min=530.65µs med=8.86ms max=96.64ms   |
-
-### JSON Sync Method 128 VUS Result
-
-| framework          | ws_msgs_received |
-| ------------------ | ---------------- |
-| tokio-tungstenite  | 107341.626999/s  |
-| bun-websocket      | 103615.608203/s  |
-| uwebsocket-js      | 100386.438146/s  |
-| fasthttp-websocket | 96270.837763/s   |
-
-### JSON Async Method 128 VUS Result
-
-| framework          | ws_msgs_received |
-| ------------------ | ---------------- |
-| tokio-tungstenite  | 434321.783546/s  |
-| bun-websocket      | 620611.021552/s  |
-| uwebsocket-js      | 560937.655412/s  |
-| fasthttp-websocket | 531082.260734/s  |
 
 ## Contribution
 
@@ -176,18 +211,35 @@ for `bun-websocket`, the test methods are separate because Bun does not support 
 [Install K6](https://k6.io/docs/get-started/installation/) on your local and then run
 
 ```sh
-make benchmark:all
-```
+# Run comprehensive benchmarks for all frameworks
+make benchmark-comprehensive
 
-replace `all` with a specific test method.
+# Or run individual test methods
+make benchmark-all
+```
 
 The test methods list (or can be found in `Makefile`):
 
-- `all`
-- `connection`
-- `plain-async`
-- `plain-sync`
-- `json-async`
-- `json-sync`
-- `binary-async`
-- `binary-sync`
+**Comprehensive Benchmarks:**
+
+- `benchmark-comprehensive` - Test all frameworks with all methods and extract results
+- `benchmark-all` - Run all tests across all frameworks systematically
+- `extract-results` - Parse and display benchmark results
+
+**Direct Script Usage:**
+
+- `./websocket_benchmark.sh` - Run complete benchmark suite (same as `both`)
+- `./websocket_benchmark.sh benchmark` - Only run benchmarks
+- `./websocket_benchmark.sh extract` - Only parse existing results
+- `./websocket_benchmark.sh help` - Show usage information
+
+**Individual Tests:**
+
+- `benchmark-individual` - Run individual test methods for the currently running framework
+- `connection` - Test WebSocket connection establishment speed
+- `plain-async` - Test plain text messaging (async)
+- `plain-sync` - Test plain text messaging (sync)
+- `json-async` - Test JSON messaging (async)
+- `json-sync` - Test JSON messaging (sync)
+- `binary-async` - Test binary messaging (async)
+- `binary-sync` - Test binary messaging (sync)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,10 +6,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "4.0"
+          cpus: "2.0"
           memory: 1G
         reservations:
-          cpus: "4.0"
+          cpus: "2.0"
           memory: 1G
 
   fasthttp-websocket:
@@ -19,10 +19,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "4.0"
+          cpus: "2.0"
           memory: 1G
         reservations:
-          cpus: "4.0"
+          cpus: "2.0"
           memory: 1G
 
   gorilla-websocket:
@@ -32,10 +32,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "4.0"
+          cpus: "2.0"
           memory: 1G
         reservations:
-          cpus: "4.0"
+          cpus: "2.0"
           memory: 1G
 
   uwebsocket-js:
@@ -45,10 +45,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "4.0"
+          cpus: "2.0"
           memory: 1G
         reservations:
-          cpus: "4.0"
+          cpus: "2.0"
           memory: 1G
 
   bun-websocket-plain:
@@ -60,10 +60,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "4.0"
+          cpus: "2.0"
           memory: 1G
         reservations:
-          cpus: "4.0"
+          cpus: "2.0"
           memory: 1G
 
   bun-websocket-json:
@@ -75,10 +75,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "4.0"
+          cpus: "2.0"
           memory: 1G
         reservations:
-          cpus: "4.0"
+          cpus: "2.0"
           memory: 1G
 
   bun-websocket-binary:
@@ -90,10 +90,23 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "4.0"
+          cpus: "2.0"
           memory: 1G
         reservations:
-          cpus: "4.0"
+          cpus: "2.0"
+          memory: 1G
+
+  websocketpp:
+    build: ./frameworks/websocketpp
+    ports:
+      - 9001:9001
+    deploy:
+      resources:
+        limits:
+          cpus: "2.0"
+          memory: 1G
+        reservations:
+          cpus: "2.0"
           memory: 1G
 
   sib:
@@ -103,8 +116,8 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "4.0"
+          cpus: "2.0"
           memory: 1G
         reservations:
-          cpus: "4.0"
+          cpus: "2.0"
           memory: 1G

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,3 +1,6 @@
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/valyala/tcplisten v1.0.0/go.mod h1:T0xQ8SeCZGxckz9qRXTfG43PvQ/mcWh7FwZEA7Ioqkc=
+golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.13.0/go.mod h1:LTmsnFJwVN6bCy1rVCoS+qHT1HhALEFxKncY3WNNh4U=
 golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=

--- a/results/vus-16/bun-websocket/binary-async.txt
+++ b/results/vus-16/bun-websocket/binary-async.txt
@@ -1,0 +1,69 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/binary-async.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (03.2s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  63% ] 16 VUs  3.2s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 48      7.177446/s
+    checks_succeeded...................: 100.00% 48 out of 48
+    checks_failed......................: 0.00%   0 out of 48
+
+    ✓ expected ${this} to be a number
+    ✓ expected ${this} to equal +0
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=6.63s  min=6.54s  med=6.64s  max=6.68s   p(90)=6.67s   p(95)=6.67s  
+    iterations...............................: 16      2.392482/s
+    vus......................................: 16      min=16          max=16
+    vus_max..................................: 16      min=16          max=16
+
+    NETWORK
+    data_received............................: 29 MB   4.3 MB/s
+    data_sent................................: 16 MB   2.4 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=7.28ms min=3.65ms med=4.64ms max=12.02ms p(90)=11.99ms p(95)=12.01ms
+    ws_msgs_received.........................: 1600000 239248.186499/s
+    ws_msgs_sent.............................: 1600000 239248.186499/s
+    ws_session_duration......................: avg=6.63s  min=6.54s  med=6.64s  max=6.68s   p(90)=6.67s   p(95)=6.67s  
+    ws_sessions..............................: 16      2.392482/s
+
+
+
+
+running (06.7s), 00/16 VUs, 16 complete and 0 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/bun-websocket/binary-sync.txt
+++ b/results/vus-16/bun-websocket/binary-sync.txt
@@ -1,0 +1,143 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/binary-sync.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (08.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (09.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (10.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (11.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (12.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (13.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (14.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (15.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (16.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (17.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (18.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (19.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (20.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (21.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (22.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (23.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (24.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (25.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (26.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (27.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (28.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (29.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (30.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (31.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (32.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (33.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (34.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (35.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+time="2025-10-06T13:48:38+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
+
+
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 16      min=16         max=16
+    vus_max............................: 16      min=16         max=16
+
+    NETWORK
+    data_received......................: 21 MB   613 kB/s
+    data_sent..........................: 12 MB   340 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=7.69ms min=5.8ms med=7.62ms max=12.24ms p(90)=10.27ms p(95)=12.24ms
+    ws_msgs_received...................: 1191052 34028.915716/s
+    ws_msgs_sent.......................: 1191068 34029.372843/s
+    ws_sessions........................: 16      0.457128/s
+
+
+
+
+running (35.0s), 00/16 VUs, 0 complete and 16 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/bun-websocket/connection.txt
+++ b/results/vus-16/bun-websocket/connection.txt
@@ -1,0 +1,59 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/connection.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 8477 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 17757 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 26468 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 34244 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 42480 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 42520   8499.867364/s
+    checks_succeeded...................: 100.00% 42520 out of 42520
+    checks_failed......................: 0.00%   0 out of 42520
+
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=1.87ms min=520.62µs med=1.69ms max=58.2ms  p(90)=2.47ms p(95)=2.84ms
+    iterations...............................: 42520  8499.867364/s
+    vus......................................: 16     min=16        max=16
+    vus_max..................................: 16     min=16        max=16
+
+    NETWORK
+    data_received............................: 7.1 MB 1.4 MB/s
+    data_sent................................: 8.5 MB 1.7 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=1.84ms min=499.66µs med=1.65ms max=58.16ms p(90)=2.43ms p(95)=2.8ms 
+    ws_session_duration......................: avg=1.86ms min=512µs    med=1.67ms max=58.18ms p(90)=2.45ms p(95)=2.82ms
+    ws_sessions..............................: 42520  8499.867364/s
+
+
+
+
+running (05.0s), 00/16 VUs, 42520 complete and 0 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/bun-websocket/json-async.txt
+++ b/results/vus-16/bun-websocket/json-async.txt
@@ -1,0 +1,66 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/json-async.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 3 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 03/16 VUs, 16 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 57      8.796509/s
+    checks_succeeded...................: 100.00% 57 out of 57
+    checks_failed......................: 0.00%   0 out of 57
+
+    ✓ expected ${this} to be a number
+    ✓ expected ${this} to equal +0
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=4.51s  min=1.51s  med=5.05s max=5.16s   p(90)=5.16s   p(95)=5.16s  
+    iterations...............................: 19      2.93217/s
+    vus......................................: 3       min=3          max=16
+    vus_max..................................: 16      min=16         max=16
+
+    NETWORK
+    data_received............................: 34 MB   5.2 MB/s
+    data_sent................................: 42 MB   6.4 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=5.95ms min=1.09ms med=4.8ms max=12.56ms p(90)=12.27ms p(95)=12.54ms
+    ws_msgs_received.........................: 1900000 293216.98072/s
+    ws_msgs_sent.............................: 1900000 293216.98072/s
+    ws_session_duration......................: avg=4.51s  min=1.51s  med=5.05s max=5.16s   p(90)=5.16s   p(95)=5.16s  
+    ws_sessions..............................: 19      2.93217/s
+
+
+
+
+running (06.5s), 00/16 VUs, 19 complete and 0 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/bun-websocket/json-sync.txt
+++ b/results/vus-16/bun-websocket/json-sync.txt
@@ -1,0 +1,143 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/json-sync.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (08.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (09.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (10.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (11.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (12.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (13.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (14.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (15.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (16.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (17.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (18.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (19.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (20.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (21.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (22.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (23.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (24.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (25.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (26.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (27.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (28.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (29.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (30.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (31.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (32.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (33.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (34.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (35.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+time="2025-10-06T13:47:23+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
+
+
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 16      min=16         max=16
+    vus_max............................: 16      min=16         max=16
+
+    NETWORK
+    data_received......................: 23 MB   656 kB/s
+    data_sent..........................: 28 MB   803 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=7.35ms min=6.68ms med=7.39ms max=7.85ms p(90)=7.72ms p(95)=7.77ms
+    ws_msgs_received...................: 1284815 36708.43469/s
+    ws_msgs_sent.......................: 1284830 36708.863255/s
+    ws_sessions........................: 16      0.457136/s
+
+
+
+
+running (35.0s), 00/16 VUs, 0 complete and 16 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/bun-websocket/plain-async.txt
+++ b/results/vus-16/bun-websocket/plain-async.txt
@@ -1,0 +1,74 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/plain-async.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 12 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 13/16 VUs, 16 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 13/16 VUs, 16 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (08.0s), 13/16 VUs, 16 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (09.0s), 07/16 VUs, 22 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 58      6.416043/s
+    checks_succeeded...................: 100.00% 58 out of 58
+    checks_failed......................: 0.00%   0 out of 58
+
+    ✓ expected ${this} to match /number\:\s[0-9]+/
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=4.55s  min=4s      med=4.54s  max=5.15s p(90)=5.01s   p(95)=5.07s  
+    iterations...............................: 29      3.208022/s
+    vus......................................: 7       min=7           max=16
+    vus_max..................................: 16      min=16          max=16
+
+    NETWORK
+    data_received............................: 43 MB   4.8 MB/s
+    data_sent................................: 55 MB   6.1 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=7.26ms min=970.7µs med=5.98ms max=16ms  p(90)=13.09ms p(95)=14.47ms
+    ws_msgs_received.........................: 2900000 320802.173579/s
+    ws_msgs_sent.............................: 2900000 320802.173579/s
+    ws_session_duration......................: avg=4.55s  min=4s      med=4.54s  max=5.15s p(90)=5.01s   p(95)=5.07s  
+    ws_sessions..............................: 29      3.208022/s
+
+
+
+
+running (09.0s), 00/16 VUs, 29 complete and 0 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/bun-websocket/plain-sync.txt
+++ b/results/vus-16/bun-websocket/plain-sync.txt
@@ -1,0 +1,143 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/plain-sync.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (08.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (09.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (10.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (11.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (12.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (13.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (14.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (15.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (16.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (17.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (18.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (19.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (20.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (21.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (22.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (23.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (24.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (25.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (26.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (27.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (28.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (29.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (30.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (31.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (32.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (33.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (34.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (35.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+time="2025-10-06T13:46:05+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
+
+
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 16      min=16         max=16
+    vus_max............................: 16      min=16         max=16
+
+    NETWORK
+    data_received......................: 19 MB   547 kB/s
+    data_sent..........................: 24 MB   694 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=5.36ms min=4.87ms med=5.31ms max=6.32ms p(90)=5.85ms p(95)=6.1ms
+    ws_msgs_received...................: 1286958 36769.199034/s
+    ws_msgs_sent.......................: 1286974 36769.656164/s
+    ws_sessions........................: 16      0.45713/s
+
+
+
+
+running (35.0s), 00/16 VUs, 0 complete and 16 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/fasthttp-websocket/binary-async.txt
+++ b/results/vus-16/fasthttp-websocket/binary-async.txt
@@ -1,0 +1,66 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/binary-async.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 48      7.048451/s
+    checks_succeeded...................: 100.00% 48 out of 48
+    checks_failed......................: 0.00%   0 out of 48
+
+    ✓ expected ${this} to be a number
+    ✓ expected ${this} to equal +0
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=6.74s  min=6.62s  med=6.75s  max=6.8s    p(90)=6.8s    p(95)=6.8s   
+    iterations...............................: 16      2.349484/s
+    vus......................................: 16      min=16          max=16
+    vus_max..................................: 16      min=16          max=16
+
+    NETWORK
+    data_received............................: 9.6 MB  1.4 MB/s
+    data_sent................................: 16 MB   2.3 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=8.84ms min=3.46ms med=8.64ms max=13.98ms p(90)=13.88ms p(95)=13.92ms
+    ws_msgs_received.........................: 1600000 234948.363489/s
+    ws_msgs_sent.............................: 1600000 234948.363489/s
+    ws_session_duration......................: avg=6.74s  min=6.62s  med=6.75s  max=6.8s    p(90)=6.8s    p(95)=6.8s   
+    ws_sessions..............................: 16      2.349484/s
+
+
+
+
+running (06.8s), 00/16 VUs, 16 complete and 0 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/fasthttp-websocket/binary-sync.txt
+++ b/results/vus-16/fasthttp-websocket/binary-sync.txt
@@ -1,0 +1,143 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/binary-sync.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (08.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (09.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (10.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (11.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (12.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (13.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (14.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (15.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (16.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (17.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (18.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (19.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (20.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (21.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (22.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (23.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (24.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (25.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (26.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (27.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (28.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (29.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (30.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (31.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (32.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (33.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (34.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (35.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+time="2025-10-06T13:25:46+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
+
+
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 16      min=16         max=16
+    vus_max............................: 16      min=16         max=16
+
+    NETWORK
+    data_received......................: 6.3 MB  181 kB/s
+    data_sent..........................: 11 MB   301 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=4.92ms min=3.1ms med=5ms max=6.39ms p(90)=6.19ms p(95)=6.24ms
+    ws_msgs_received...................: 1052389 30066.910145/s
+    ws_msgs_sent.......................: 1052405 30067.367268/s
+    ws_sessions........................: 16      0.457122/s
+
+
+
+
+running (35.0s), 00/16 VUs, 0 complete and 16 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/fasthttp-websocket/connection.txt
+++ b/results/vus-16/fasthttp-websocket/connection.txt
@@ -1,0 +1,59 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/connection.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 8522 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 17151 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 24980 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 33554 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 42044 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 42074   8412.220813/s
+    checks_succeeded...................: 100.00% 42074 out of 42074
+    checks_failed......................: 0.00%   0 out of 42074
+
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=1.89ms min=337.79µs med=1.73ms max=34.72ms p(90)=2.55ms p(95)=2.97ms
+    iterations...............................: 42074  8412.220813/s
+    vus......................................: 16     min=16        max=16
+    vus_max..................................: 16     min=16        max=16
+
+    NETWORK
+    data_received............................: 7.7 MB 1.5 MB/s
+    data_sent................................: 8.5 MB 1.7 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=1.86ms min=311.83µs med=1.69ms max=34.66ms p(90)=2.52ms p(95)=2.94ms
+    ws_session_duration......................: avg=1.88ms min=325.16µs med=1.71ms max=34.7ms  p(90)=2.54ms p(95)=2.96ms
+    ws_sessions..............................: 42074  8412.220813/s
+
+
+
+
+running (05.0s), 00/16 VUs, 42074 complete and 0 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/fasthttp-websocket/json-async.txt
+++ b/results/vus-16/fasthttp-websocket/json-async.txt
@@ -1,0 +1,69 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/json-async.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 15/16 VUs, 1 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 14/16 VUs, 2 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 48      6.277/s
+    checks_succeeded...................: 100.00% 48 out of 48
+    checks_failed......................: 0.00%   0 out of 48
+
+    ✓ expected ${this} to be a number
+    ✓ expected ${this} to equal +0
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=7.21s  min=5.45s  med=7.33s  max=7.64s   p(90)=7.61s   p(95)=7.62s 
+    iterations...............................: 16      2.092333/s
+    vus......................................: 14      min=14          max=16
+    vus_max..................................: 16      min=16          max=16
+
+    NETWORK
+    data_received............................: 29 MB   3.7 MB/s
+    data_sent................................: 35 MB   4.6 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=8.74ms min=4.03ms med=7.92ms max=14.53ms p(90)=13.56ms p(95)=14.5ms
+    ws_msgs_received.........................: 1600000 209233.336363/s
+    ws_msgs_sent.............................: 1600000 209233.336363/s
+    ws_session_duration......................: avg=7.21s  min=5.45s  med=7.33s  max=7.64s   p(90)=7.61s   p(95)=7.62s 
+    ws_sessions..............................: 16      2.092333/s
+
+
+
+
+running (07.6s), 00/16 VUs, 16 complete and 0 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/fasthttp-websocket/json-sync.txt
+++ b/results/vus-16/fasthttp-websocket/json-sync.txt
@@ -1,0 +1,143 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/json-sync.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (08.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (09.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (10.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (11.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (12.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (13.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (14.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (15.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (16.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (17.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (18.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (19.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (20.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (21.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (22.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (23.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (24.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (25.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (26.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (27.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (28.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (29.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (30.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (31.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (32.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (33.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (34.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (35.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+time="2025-10-06T13:24:51+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
+
+
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 16      min=16         max=16
+    vus_max............................: 16      min=16         max=16
+
+    NETWORK
+    data_received......................: 20 MB   579 kB/s
+    data_sent..........................: 25 MB   709 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=6.94ms min=5.14ms med=7.39ms max=8.44ms p(90)=8.35ms p(95)=8.4ms
+    ws_msgs_received...................: 1135642 32446.244966/s
+    ws_msgs_sent.......................: 1135658 32446.702099/s
+    ws_sessions........................: 16      0.457133/s
+
+
+
+
+running (35.0s), 00/16 VUs, 0 complete and 16 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/fasthttp-websocket/plain-async.txt
+++ b/results/vus-16/fasthttp-websocket/plain-async.txt
@@ -1,0 +1,74 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/plain-async.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 16 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 16/16 VUs, 16 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 16/16 VUs, 16 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (08.0s), 16/16 VUs, 16 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (09.0s), 16/16 VUs, 16 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 64      6.531796/s
+    checks_succeeded...................: 100.00% 64 out of 64
+    checks_failed......................: 0.00%   0 out of 64
+
+    ✓ expected ${this} to match /number\:\s[0-9]+/
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=4.85s   min=4.61s   med=4.86s   max=4.97s    p(90)=4.93s    p(95)=4.94s   
+    iterations...............................: 32      3.265898/s
+    vus......................................: 16      min=16          max=16
+    vus_max..................................: 16      min=16          max=16
+
+    NETWORK
+    data_received............................: 48 MB   4.9 MB/s
+    data_sent................................: 61 MB   6.2 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=42.56ms min=997.7µs med=15.75ms max=149.77ms p(90)=122.11ms p(95)=124.35ms
+    ws_msgs_received.........................: 3200000 326589.798314/s
+    ws_msgs_sent.............................: 3200000 326589.798314/s
+    ws_session_duration......................: avg=4.85s   min=4.61s   med=4.86s   max=4.97s    p(90)=4.93s    p(95)=4.94s   
+    ws_sessions..............................: 32      3.265898/s
+
+
+
+
+running (09.8s), 00/16 VUs, 32 complete and 0 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/fasthttp-websocket/plain-sync.txt
+++ b/results/vus-16/fasthttp-websocket/plain-sync.txt
@@ -1,0 +1,143 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/plain-sync.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (08.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (09.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (10.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (11.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (12.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (13.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (14.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (15.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (16.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (17.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (18.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (19.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (20.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (21.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (22.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (23.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (24.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (25.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (26.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (27.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (28.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (29.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (30.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (31.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (32.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (33.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (34.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (35.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+time="2025-10-06T13:23:54+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
+
+
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 16      min=16         max=16
+    vus_max............................: 16      min=16         max=16
+
+    NETWORK
+    data_received......................: 19 MB   551 kB/s
+    data_sent..........................: 25 MB   699 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=5.44ms min=4.24ms med=5.37ms max=7.14ms p(90)=6.74ms p(95)=7.02ms
+    ws_msgs_received...................: 1296913 37053.646108/s
+    ws_msgs_sent.......................: 1296929 37054.103238/s
+    ws_sessions........................: 16      0.45713/s
+
+
+
+
+running (35.0s), 00/16 VUs, 0 complete and 16 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/gorilla-websocket/binary-async.txt
+++ b/results/vus-16/gorilla-websocket/binary-async.txt
@@ -1,0 +1,66 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/binary-async.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 14/16 VUs, 2 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 48      7.86966/s
+    checks_succeeded...................: 100.00% 48 out of 48
+    checks_failed......................: 0.00%   0 out of 48
+
+    ✓ expected ${this} to be a number
+    ✓ expected ${this} to equal +0
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=6.04s  min=5.94s  med=6.06s  max=6.09s  p(90)=6.09s  p(95)=6.09s 
+    iterations...............................: 16      2.62322/s
+    vus......................................: 14      min=14          max=16
+    vus_max..................................: 16      min=16          max=16
+
+    NETWORK
+    data_received............................: 9.6 MB  1.6 MB/s
+    data_sent................................: 16 MB   2.6 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=6.14ms min=4.92ms med=5.51ms max=7.53ms p(90)=7.51ms p(95)=7.53ms
+    ws_msgs_received.........................: 1600000 262322.002225/s
+    ws_msgs_sent.............................: 1600000 262322.002225/s
+    ws_session_duration......................: avg=6.04s  min=5.94s  med=6.06s  max=6.09s  p(90)=6.09s  p(95)=6.09s 
+    ws_sessions..............................: 16      2.62322/s
+
+
+
+
+running (06.1s), 00/16 VUs, 16 complete and 0 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/gorilla-websocket/binary-sync.txt
+++ b/results/vus-16/gorilla-websocket/binary-sync.txt
@@ -1,0 +1,143 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/binary-sync.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (08.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (09.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (10.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (11.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (12.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (13.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (14.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (15.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (16.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (17.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (18.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (19.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (20.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (21.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (22.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (23.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (24.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (25.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (26.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (27.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (28.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (29.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (30.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (31.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (32.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (33.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (34.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (35.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+time="2025-10-06T13:28:51+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
+
+
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 16      min=16         max=16
+    vus_max............................: 16      min=16         max=16
+
+    NETWORK
+    data_received......................: 7.2 MB  205 kB/s
+    data_sent..........................: 12 MB   341 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=6.29ms min=5.08ms med=6.31ms max=7.39ms p(90)=6.61ms p(95)=6.86ms
+    ws_msgs_received...................: 1192305 34065.377308/s
+    ws_msgs_sent.......................: 1192321 34065.834444/s
+    ws_sessions........................: 16      0.457136/s
+
+
+
+
+running (35.0s), 00/16 VUs, 0 complete and 16 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/gorilla-websocket/connection.txt
+++ b/results/vus-16/gorilla-websocket/connection.txt
@@ -1,0 +1,60 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/connection.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 7079 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 14812 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 17673 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 19349 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 20248 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 20266  4041.91578/s
+    checks_succeeded...................: 80.59% 16333 out of 20266
+    checks_failed......................: 19.40% 3933 out of 20266
+
+    ✗ status is 101
+      ↳  80% — ✓ 16333 / ✗ 3933
+
+    EXECUTION
+    iteration_duration.......................: avg=3.95ms min=387.5µs  med=2ms    max=202.43ms p(90)=9.79ms p(95)=12.63ms
+    iterations...............................: 20266  4041.91578/s
+    vus......................................: 16     min=16       max=16
+    vus_max..................................: 16     min=16       max=16
+
+    NETWORK
+    data_received............................: 2.1 MB 420 kB/s
+    data_sent................................: 3.3 MB 655 kB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=3.91ms min=362.91µs med=1.96ms max=202.4ms  p(90)=9.77ms p(95)=12.61ms
+    ws_session_duration......................: avg=3.93ms min=379.04µs med=1.99ms max=202.42ms p(90)=9.78ms p(95)=12.61ms
+    ws_sessions..............................: 20266  4041.91578/s
+
+
+
+
+running (05.0s), 00/16 VUs, 20266 complete and 0 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/gorilla-websocket/json-async.txt
+++ b/results/vus-16/gorilla-websocket/json-async.txt
@@ -1,0 +1,69 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/json-async.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 15/16 VUs, 1 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 48      6.040504/s
+    checks_succeeded...................: 100.00% 48 out of 48
+    checks_failed......................: 0.00%   0 out of 48
+
+    ✓ expected ${this} to be a number
+    ✓ expected ${this} to equal +0
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=7.61s   min=6.92s  med=7.71s  max=7.94s   p(90)=7.9s    p(95)=7.92s  
+    iterations...............................: 16      2.013501/s
+    vus......................................: 15      min=15          max=16
+    vus_max..................................: 16      min=16          max=16
+
+    NETWORK
+    data_received............................: 29 MB   3.6 MB/s
+    data_sent................................: 35 MB   4.4 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=14.33ms min=3.23ms med=17.7ms max=19.76ms p(90)=19.71ms p(95)=19.72ms
+    ws_msgs_received.........................: 1600000 201350.128115/s
+    ws_msgs_sent.............................: 1600000 201350.128115/s
+    ws_session_duration......................: avg=7.61s   min=6.92s  med=7.71s  max=7.94s   p(90)=7.9s    p(95)=7.92s  
+    ws_sessions..............................: 16      2.013501/s
+
+
+
+
+running (07.9s), 00/16 VUs, 16 complete and 0 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/gorilla-websocket/json-sync.txt
+++ b/results/vus-16/gorilla-websocket/json-sync.txt
@@ -1,0 +1,143 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/json-sync.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (08.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (09.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (10.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (11.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (12.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (13.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (14.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (15.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (16.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (17.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (18.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (19.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (20.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (21.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (22.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (23.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (24.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (25.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (26.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (27.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (28.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (29.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (30.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (31.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (32.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (33.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (34.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (35.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+time="2025-10-06T13:27:56+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
+
+
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 16      min=16         max=16
+    vus_max............................: 16      min=16         max=16
+
+    NETWORK
+    data_received......................: 22 MB   622 kB/s
+    data_sent..........................: 27 MB   761 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=5.34ms min=3.8ms med=5.52ms max=6.38ms p(90)=6.19ms p(95)=6.26ms
+    ws_msgs_received...................: 1218819 34822.879647/s
+    ws_msgs_sent.......................: 1218835 34823.336783/s
+    ws_sessions........................: 16      0.457136/s
+
+
+
+
+running (35.0s), 00/16 VUs, 0 complete and 16 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/gorilla-websocket/plain-async.txt
+++ b/results/vus-16/gorilla-websocket/plain-async.txt
@@ -1,0 +1,98 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/plain-async.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 16 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 16/16 VUs, 16 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 16/16 VUs, 16 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (08.0s), 16/16 VUs, 16 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (09.0s), 16/16 VUs, 16 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (10.0s), 14/16 VUs, 18 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (11.0s), 06/16 VUs, 26 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (12.0s), 06/16 VUs, 26 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (13.0s), 01/16 VUs, 31 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (14.0s), 01/16 VUs, 31 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (15.0s), 01/16 VUs, 31 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (16.0s), 01/16 VUs, 31 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (17.0s), 01/16 VUs, 31 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 64      3.561306/s
+    checks_succeeded...................: 100.00% 64 out of 64
+    checks_failed......................: 0.00%   0 out of 64
+
+    ✓ expected ${this} to match /number\:\s[0-9]+/
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=5.68s   min=4.57s    med=5.08s  max=13.14s  p(90)=7.6s    p(95)=7.75s  
+    iterations...............................: 32      1.780653/s
+    vus......................................: 1       min=1           max=16
+    vus_max..................................: 16      min=16          max=16
+
+    NETWORK
+    data_received............................: 48 MB   2.7 MB/s
+    data_sent................................: 61 MB   3.4 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=11.72ms min=812.62µs med=10.5ms max=38.68ms p(90)=29.18ms p(95)=36.68ms
+    ws_msgs_received.........................: 3200000 178065.293872/s
+    ws_msgs_sent.............................: 3200000 178065.293872/s
+    ws_session_duration......................: avg=5.68s   min=4.57s    med=5.08s  max=13.14s  p(90)=7.6s    p(95)=7.74s  
+    ws_sessions..............................: 32      1.780653/s
+
+
+
+
+running (18.0s), 00/16 VUs, 32 complete and 0 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/gorilla-websocket/plain-sync.txt
+++ b/results/vus-16/gorilla-websocket/plain-sync.txt
@@ -1,0 +1,152 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/plain-sync.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 1588 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 3191 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 4883 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 6355 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 7481 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 03/16 VUs, 7495 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 03/16 VUs, 7495 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (08.0s), 03/16 VUs, 7495 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (09.0s), 03/16 VUs, 7495 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (10.0s), 03/16 VUs, 7495 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (11.0s), 03/16 VUs, 7495 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (12.0s), 03/16 VUs, 7495 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (13.0s), 03/16 VUs, 7495 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (14.0s), 03/16 VUs, 7495 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (15.0s), 03/16 VUs, 7495 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (16.0s), 03/16 VUs, 7495 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (17.0s), 03/16 VUs, 7495 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (18.0s), 03/16 VUs, 7495 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (19.0s), 03/16 VUs, 7495 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (20.0s), 03/16 VUs, 7495 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (21.0s), 03/16 VUs, 7495 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (22.0s), 03/16 VUs, 7495 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (23.0s), 03/16 VUs, 7495 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (24.0s), 03/16 VUs, 7495 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (25.0s), 03/16 VUs, 7495 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (26.0s), 03/16 VUs, 7495 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (27.0s), 03/16 VUs, 7495 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (28.0s), 03/16 VUs, 7495 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (29.0s), 03/16 VUs, 7495 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (30.0s), 03/16 VUs, 7495 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (31.0s), 03/16 VUs, 7495 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (32.0s), 03/16 VUs, 7495 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (33.0s), 03/16 VUs, 7495 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (34.0s), 03/16 VUs, 7495 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (35.0s), 03/16 VUs, 7495 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 7495    214.140385/s
+    checks_succeeded...................: 0.00%   0 out of 7495
+    checks_failed......................: 100.00% 7495 out of 7495
+
+    ✗ status is 101
+      ↳  0% — ✓ 0 / ✗ 7495
+
+    EXECUTION
+    iteration_duration.......................: avg=9.72ms min=3.08ms med=9.11ms max=44.47ms  p(90)=13.58ms p(95)=15.74ms
+    iterations...............................: 7495   214.140385/s
+    vus......................................: 3      min=3          max=16
+    vus_max..................................: 16     min=16         max=16
+
+    NETWORK
+    data_received............................: 9.1 MB 260 kB/s
+    data_sent................................: 12 MB  328 kB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=9.8ms  min=3.07ms med=9.1ms  max=293.55ms p(90)=13.57ms p(95)=15.73ms
+    ws_msgs_received.........................: 590514 16871.633825/s
+    ws_msgs_sent.............................: 590517 16871.719538/s
+    ws_session_duration......................: avg=9.7ms  min=3.07ms med=9.1ms  max=44.46ms  p(90)=13.56ms p(95)=15.69ms
+    ws_sessions..............................: 7498   214.226099/s
+
+
+
+
+running (35.0s), 00/16 VUs, 7495 complete and 3 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/sib/binary-async.txt
+++ b/results/vus-16/sib/binary-async.txt
@@ -1,0 +1,63 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/binary-async.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 48      8.776788/s
+    checks_succeeded...................: 100.00% 48 out of 48
+    checks_failed......................: 0.00%   0 out of 48
+
+    ✓ expected ${this} to be a number
+    ✓ expected ${this} to equal +0
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=5.41s min=5.32s med=5.44s   max=5.46s   p(90)=5.46s   p(95)=5.46s  
+    iterations...............................: 16      2.925596/s
+    vus......................................: 16      min=16         max=16
+    vus_max..................................: 16      min=16         max=16
+
+    NETWORK
+    data_received............................: 9.6 MB  1.8 MB/s
+    data_sent................................: 16 MB   2.9 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=7.9ms min=3.3ms med=10.24ms max=10.57ms p(90)=10.52ms p(95)=10.56ms
+    ws_msgs_received.........................: 1600000 292559.60582/s
+    ws_msgs_sent.............................: 1600000 292559.60582/s
+    ws_session_duration......................: avg=5.41s min=5.32s med=5.44s   max=5.46s   p(90)=5.46s   p(95)=5.46s  
+    ws_sessions..............................: 16      2.925596/s
+
+
+
+
+running (05.5s), 00/16 VUs, 16 complete and 0 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/sib/binary-sync.txt
+++ b/results/vus-16/sib/binary-sync.txt
@@ -1,0 +1,143 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/binary-sync.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (08.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (09.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (10.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (11.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (12.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (13.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (14.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (15.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (16.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (17.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (18.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (19.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (20.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (21.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (22.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (23.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (24.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (25.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (26.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (27.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (28.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (29.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (30.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (31.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (32.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (33.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (34.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (35.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+time="2025-10-06T13:44:23+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
+
+
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 16      min=16         max=16
+    vus_max............................: 16      min=16         max=16
+
+    NETWORK
+    data_received......................: 6.1 MB  174 kB/s
+    data_sent..........................: 10 MB   290 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=10.5s min=3.75ms med=5.67ms max=34.99s p(90)=34.99s p(95)=34.99s
+    ws_msgs_received...................: 1013360 28952.664725/s
+    ws_msgs_sent.......................: 1013366 28952.83615/s
+    ws_sessions........................: 10      0.28571/s
+
+
+
+
+running (35.0s), 00/16 VUs, 0 complete and 16 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/sib/connection.txt
+++ b/results/vus-16/sib/connection.txt
@@ -1,0 +1,150 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/connection.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (08.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (09.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (10.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (11.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (12.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (13.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (14.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (15.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (16.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (17.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (18.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (19.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (20.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (21.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (22.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (23.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (24.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (25.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (26.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (27.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (28.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (29.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (30.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (31.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (32.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (33.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (34.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (35.0s), 16/16 VUs, 459 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 469    13.398208/s
+    checks_succeeded...................: 97.86% 459 out of 469
+    checks_failed......................: 2.13%  10 out of 469
+
+    ✗ status is 101
+      ↳  97% — ✓ 459 / ✗ 10
+
+    EXECUTION
+    iteration_duration.......................: avg=747.14ms min=285.66µs med=1.69ms max=34.93s p(90)=4.6ms  p(95)=5.7ms 
+    iterations...............................: 469   13.398208/s
+    vus......................................: 16    min=16      max=16
+    vus_max..................................: 16    min=16      max=16
+
+    NETWORK
+    data_received............................: 59 kB 1.7 kB/s
+    data_sent................................: 95 kB 2.7 kB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=747.03ms min=265.54µs med=1.62ms max=34.93s p(90)=4.51ms p(95)=5.66ms
+    ws_session_duration......................: avg=747.09ms min=278.16µs med=1.67ms max=34.93s p(90)=4.57ms p(95)=5.68ms
+    ws_sessions..............................: 469   13.398208/s
+
+
+
+
+running (35.0s), 00/16 VUs, 469 complete and 6 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/sib/json-async.txt
+++ b/results/vus-16/sib/json-async.txt
@@ -1,0 +1,154 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/json-async.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 6 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 7 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 10 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 14/16 VUs, 12 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 13/16 VUs, 13 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (08.0s), 13/16 VUs, 13 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (09.0s), 13/16 VUs, 13 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (10.0s), 13/16 VUs, 13 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (11.0s), 13/16 VUs, 13 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (12.0s), 13/16 VUs, 13 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (13.0s), 13/16 VUs, 13 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (14.0s), 13/16 VUs, 13 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (15.0s), 13/16 VUs, 13 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (16.0s), 13/16 VUs, 13 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (17.0s), 13/16 VUs, 13 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (18.0s), 13/16 VUs, 13 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (19.0s), 13/16 VUs, 13 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (20.0s), 13/16 VUs, 13 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (21.0s), 13/16 VUs, 13 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (22.0s), 13/16 VUs, 13 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (23.0s), 13/16 VUs, 13 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (24.0s), 13/16 VUs, 13 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (25.0s), 13/16 VUs, 13 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (26.0s), 13/16 VUs, 13 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (27.0s), 13/16 VUs, 13 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (28.0s), 13/16 VUs, 13 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (29.0s), 13/16 VUs, 13 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (30.0s), 13/16 VUs, 13 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (31.0s), 13/16 VUs, 13 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (32.0s), 13/16 VUs, 13 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (33.0s), 13/16 VUs, 13 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (34.0s), 13/16 VUs, 13 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (35.0s), 13/16 VUs, 13 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 41     1.171749/s
+    checks_succeeded...................: 95.12% 39 out of 41
+    checks_failed......................: 4.87%  2 out of 41
+
+    ✓ expected ${this} to be a number
+    ✓ expected ${this} to equal +0
+    ✗ status is 101
+      ↳  86% — ✓ 13 / ✗ 2
+
+    EXECUTION
+    iteration_duration.......................: avg=6.71s  min=1.17s    med=2.52s    max=35s p(90)=22.28s p(95)=35s
+    iterations...............................: 15      0.428689/s
+    vus......................................: 13      min=13         max=16
+    vus_max..................................: 16      min=16         max=16
+
+    NETWORK
+    data_received............................: 23 MB   665 kB/s
+    data_sent................................: 29 MB   813 kB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=11.14s min=664.54µs med=691.61ms max=35s p(90)=35s    p(95)=35s
+    ws_msgs_received.........................: 1300000 37153.030704/s
+    ws_msgs_sent.............................: 1300000 37153.030704/s
+    ws_session_duration......................: avg=6.71s  min=1.17s    med=2.52s    max=35s p(90)=22.28s p(95)=35s
+    ws_sessions..............................: 19      0.543006/s
+
+
+
+
+running (35.0s), 00/16 VUs, 15 complete and 11 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/sib/json-sync.txt
+++ b/results/vus-16/sib/json-sync.txt
@@ -1,0 +1,143 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/json-sync.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (08.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (09.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (10.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (11.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (12.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (13.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (14.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (15.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (16.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (17.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (18.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (19.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (20.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (21.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (22.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (23.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (24.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (25.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (26.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (27.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (28.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (29.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (30.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (31.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (32.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (33.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (34.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (35.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+time="2025-10-06T13:42:40+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
+
+
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 16     min=16         max=16
+    vus_max............................: 16     min=16         max=16
+
+    NETWORK
+    data_received......................: 18 MB  516 kB/s
+    data_sent..........................: 22 MB  629 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=4.19ms min=2.66ms med=4.32ms max=5.15ms p(90)=4.98ms p(95)=5.07ms
+    ws_msgs_received...................: 985601 28158.671323/s
+    ws_msgs_sent.......................: 985606 28158.814174/s
+    ws_sessions........................: 6      0.17142/s
+
+
+
+
+running (35.0s), 00/16 VUs, 0 complete and 16 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/sib/plain-async.txt
+++ b/results/vus-16/sib/plain-async.txt
@@ -1,0 +1,153 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/plain-async.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 5 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 6 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (08.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (09.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (10.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (11.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (12.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (13.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (14.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (15.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (16.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (17.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (18.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (19.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (20.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (21.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (22.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (23.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (24.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (25.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (26.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (27.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (28.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (29.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (30.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (31.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (32.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (33.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (34.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (35.0s), 16/16 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 26     0.742803/s
+    checks_succeeded...................: 61.53% 16 out of 26
+    checks_failed......................: 38.46% 10 out of 26
+
+    ✓ expected ${this} to match /number\:\s[0-9]+/
+    ✗ status is 101
+      ↳  44% — ✓ 8 / ✗ 10
+
+    EXECUTION
+    iteration_duration.......................: avg=19.82s min=709.95ms med=34.39s max=35s p(90)=35s p(95)=35s
+    iterations...............................: 18     0.514248/s
+    vus......................................: 16     min=16         max=16
+    vus_max..................................: 16     min=16         max=16
+
+    NETWORK
+    data_received............................: 12 MB  340 kB/s
+    data_sent................................: 15 MB  432 kB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=21.92s min=513.87µs med=33.8s  max=35s p(90)=35s p(95)=35s
+    ws_msgs_received.........................: 800000 22855.475713/s
+    ws_msgs_sent.............................: 800000 22855.475713/s
+    ws_session_duration......................: avg=19.82s min=709.93ms med=34.39s max=35s p(90)=35s p(95)=35s
+    ws_sessions..............................: 22     0.628526/s
+
+
+
+
+running (35.0s), 00/16 VUs, 18 complete and 6 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/sib/plain-sync.txt
+++ b/results/vus-16/sib/plain-sync.txt
@@ -1,0 +1,143 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/plain-sync.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (08.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (09.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (10.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (11.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (12.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (13.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (14.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (15.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (16.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (17.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (18.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (19.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (20.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (21.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (22.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (23.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (24.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (25.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (26.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (27.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (28.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (29.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (30.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (31.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (32.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (33.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (34.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (35.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+time="2025-10-06T13:40:58+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
+
+
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 16     min=16         max=16
+    vus_max............................: 16     min=16         max=16
+
+    NETWORK
+    data_received......................: 14 MB  408 kB/s
+    data_sent..........................: 18 MB  515 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=13.46s min=1.91ms med=4.42ms max=34.99s p(90)=34.99s p(95)=34.99s
+    ws_msgs_received...................: 933923 26682.32959/s
+    ws_msgs_sent.......................: 933930 26682.529581/s
+    ws_sessions........................: 13     0.371412/s
+
+
+
+
+running (35.0s), 00/16 VUs, 0 complete and 16 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/tokio-tungstenite/binary-async.txt
+++ b/results/vus-16/tokio-tungstenite/binary-async.txt
@@ -1,0 +1,63 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/binary-async.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 48      8.917006/s
+    checks_succeeded...................: 100.00% 48 out of 48
+    checks_failed......................: 0.00%   0 out of 48
+
+    ✓ expected ${this} to be a number
+    ✓ expected ${this} to equal +0
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=5.33s   min=5.18s  med=5.36s   max=5.38s   p(90)=5.37s   p(95)=5.38s  
+    iterations...............................: 16      2.972335/s
+    vus......................................: 16      min=16          max=16
+    vus_max..................................: 16      min=16          max=16
+
+    NETWORK
+    data_received............................: 9.6 MB  1.8 MB/s
+    data_sent................................: 16 MB   3.0 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=11.93ms min=3.69ms med=13.34ms max=24.82ms p(90)=16.34ms p(95)=18.47ms
+    ws_msgs_received.........................: 1600000 297233.517612/s
+    ws_msgs_sent.............................: 1600000 297233.517612/s
+    ws_session_duration......................: avg=5.33s   min=5.18s  med=5.36s   max=5.38s   p(90)=5.37s   p(95)=5.38s  
+    ws_sessions..............................: 16      2.972335/s
+
+
+
+
+running (05.4s), 00/16 VUs, 16 complete and 0 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/tokio-tungstenite/binary-sync.txt
+++ b/results/vus-16/tokio-tungstenite/binary-sync.txt
@@ -1,0 +1,143 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/binary-sync.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (08.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (09.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (10.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (11.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (12.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (13.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (14.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (15.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (16.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (17.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (18.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (19.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (20.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (21.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (22.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (23.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (24.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (25.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (26.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (27.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (28.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (29.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (30.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (31.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (32.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (33.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (34.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (35.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+time="2025-10-06T13:22:30+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
+
+
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 16      min=16         max=16
+    vus_max............................: 16      min=16         max=16
+
+    NETWORK
+    data_received......................: 7.8 MB  224 kB/s
+    data_sent..........................: 13 MB   374 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=5.56ms min=3.05ms med=5.59ms max=7.78ms p(90)=6.92ms p(95)=7.15ms
+    ws_msgs_received...................: 1307226 37347.855585/s
+    ws_msgs_sent.......................: 1307242 37348.31271/s
+    ws_sessions........................: 16      0.457125/s
+
+
+
+
+running (35.0s), 00/16 VUs, 0 complete and 16 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/tokio-tungstenite/connection.txt
+++ b/results/vus-16/tokio-tungstenite/connection.txt
@@ -1,0 +1,59 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/connection.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 8685 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 17005 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 25263 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 32211 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 39971 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 40019   8001.300394/s
+    checks_succeeded...................: 100.00% 40019 out of 40019
+    checks_failed......................: 0.00%   0 out of 40019
+
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=1.99ms min=540.75µs med=1.8ms  max=55.25ms p(90)=2.63ms p(95)=3.04ms
+    iterations...............................: 40019  8001.300394/s
+    vus......................................: 16     min=16        max=16
+    vus_max..................................: 16     min=16        max=16
+
+    NETWORK
+    data_received............................: 5.2 MB 1.0 MB/s
+    data_sent................................: 8.0 MB 1.6 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=1.96ms min=476.37µs med=1.76ms max=55.22ms p(90)=2.59ms p(95)=3ms   
+    ws_session_duration......................: avg=1.98ms min=532.5µs  med=1.78ms max=55.24ms p(90)=2.61ms p(95)=3.03ms
+    ws_sessions..............................: 40019  8001.300394/s
+
+
+
+
+running (05.0s), 00/16 VUs, 40019 complete and 0 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/tokio-tungstenite/json-async.txt
+++ b/results/vus-16/tokio-tungstenite/json-async.txt
@@ -1,0 +1,75 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/json-async.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 14 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 14/16 VUs, 16 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 14/16 VUs, 16 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (08.0s), 14/16 VUs, 16 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (09.0s), 13/16 VUs, 17 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 90      9.81675/s
+    checks_succeeded...................: 100.00% 90 out of 90
+    checks_failed......................: 0.00%   0 out of 90
+
+    ✓ expected ${this} to be a number
+    ✓ expected ${this} to equal +0
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=4.59s  min=4.15s    med=4.68s  max=5.23s   p(90)=4.96s   p(95)=5.02s  
+    iterations...............................: 30      3.27225/s
+    vus......................................: 13      min=13          max=16
+    vus_max..................................: 16      min=16          max=16
+
+    NETWORK
+    data_received............................: 54 MB   5.9 MB/s
+    data_sent................................: 66 MB   7.2 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=9.29ms min=511.25µs med=4.59ms max=25.85ms p(90)=25.34ms p(95)=25.61ms
+    ws_msgs_received.........................: 3000000 327224.988122/s
+    ws_msgs_sent.............................: 3000000 327224.988122/s
+    ws_session_duration......................: avg=4.59s  min=4.15s    med=4.68s  max=5.23s   p(90)=4.96s   p(95)=5.02s  
+    ws_sessions..............................: 30      3.27225/s
+
+
+
+
+running (09.2s), 00/16 VUs, 30 complete and 0 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/tokio-tungstenite/json-sync.txt
+++ b/results/vus-16/tokio-tungstenite/json-sync.txt
@@ -1,0 +1,143 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/json-sync.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (08.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (09.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (10.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (11.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (12.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (13.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (14.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (15.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (16.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (17.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (18.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (19.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (20.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (21.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (22.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (23.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (24.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (25.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (26.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (27.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (28.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (29.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (30.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (31.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (32.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (33.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (34.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (35.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+time="2025-10-06T13:21:13+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
+
+
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 16      min=16         max=16
+    vus_max............................: 16      min=16         max=16
+
+    NETWORK
+    data_received......................: 24 MB   678 kB/s
+    data_sent..........................: 29 MB   830 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=6.48ms min=4.64ms med=6.84ms max=7.42ms p(90)=7.27ms p(95)=7.35ms
+    ws_msgs_received...................: 1327994 37935.617767/s
+    ws_msgs_sent.......................: 1328010 37936.074824/s
+    ws_sessions........................: 16      0.457058/s
+
+
+
+
+running (35.0s), 00/16 VUs, 0 complete and 16 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/tokio-tungstenite/plain-async.txt
+++ b/results/vus-16/tokio-tungstenite/plain-async.txt
@@ -1,0 +1,74 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/plain-async.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 2 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 14/16 VUs, 4 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 09/16 VUs, 9 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (08.0s), 02/16 VUs, 16 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (09.0s), 02/16 VUs, 16 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 36      3.648179/s
+    checks_succeeded...................: 100.00% 36 out of 36
+    checks_failed......................: 0.00%   0 out of 36
+
+    ✓ expected ${this} to match /number\:\s[0-9]+/
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=6.36s   min=2.55s  med=6.77s   max=9.86s   p(90)=8.03s   p(95)=9.86s  
+    iterations...............................: 18      1.824089/s
+    vus......................................: 2       min=2          max=16
+    vus_max..................................: 16      min=16         max=16
+
+    NETWORK
+    data_received............................: 27 MB   2.7 MB/s
+    data_sent................................: 34 MB   3.4 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=11.61ms min=2.81ms med=11.25ms max=53.29ms p(90)=13.24ms p(95)=20.85ms
+    ws_msgs_received.........................: 1800000 182408.94728/s
+    ws_msgs_sent.............................: 1800000 182408.94728/s
+    ws_session_duration......................: avg=6.36s   min=2.55s  med=6.77s   max=9.86s   p(90)=8.03s   p(95)=9.86s  
+    ws_sessions..............................: 18      1.824089/s
+
+
+
+
+running (09.9s), 00/16 VUs, 18 complete and 0 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/tokio-tungstenite/plain-sync.txt
+++ b/results/vus-16/tokio-tungstenite/plain-sync.txt
@@ -1,0 +1,143 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/plain-sync.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (08.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (09.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (10.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (11.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (12.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (13.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (14.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (15.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (16.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (17.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (18.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (19.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (20.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (21.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (22.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (23.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (24.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (25.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (26.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (27.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (28.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (29.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (30.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (31.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (32.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (33.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (34.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (35.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+time="2025-10-06T13:19:51+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
+
+
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 16      min=16         max=16
+    vus_max............................: 16      min=16         max=16
+
+    NETWORK
+    data_received......................: 21 MB   600 kB/s
+    data_sent..........................: 27 MB   762 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=4.8ms min=2.96ms med=5.36ms max=5.99ms p(90)=5.94ms p(95)=5.95ms
+    ws_msgs_received...................: 1412248 40348.814243/s
+    ws_msgs_sent.......................: 1412264 40349.271373/s
+    ws_sessions........................: 16      0.45713/s
+
+
+
+
+running (35.0s), 00/16 VUs, 0 complete and 16 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/uwebsocket-js/binary-async.txt
+++ b/results/vus-16/uwebsocket-js/binary-async.txt
@@ -1,0 +1,81 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/binary-async.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.3s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5s
+
+running (06.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (08.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (09.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (10.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (11.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 48      4.04896/s
+    checks_succeeded...................: 100.00% 48 out of 48
+    checks_failed......................: 0.00%   0 out of 48
+
+    ✓ expected ${this} to be a number
+    ✓ expected ${this} to equal +0
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=11.7s   min=11.52s med=11.69s  max=11.85s  p(90)=11.83s  p(95)=11.84s 
+    iterations...............................: 16      1.349653/s
+    vus......................................: 16      min=16          max=16
+    vus_max..................................: 16      min=16          max=16
+
+    NETWORK
+    data_received............................: 9.6 MB  810 kB/s
+    data_sent................................: 16 MB   1.3 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=15.48ms min=4.5ms  med=18.14ms max=21.91ms p(90)=21.85ms p(95)=21.87ms
+    ws_msgs_received.........................: 1600000 134965.345539/s
+    ws_msgs_sent.............................: 1600000 134965.345539/s
+    ws_session_duration......................: avg=11.7s   min=11.52s med=11.69s  max=11.85s  p(90)=11.83s  p(95)=11.84s 
+    ws_sessions..............................: 16      1.349653/s
+
+
+
+
+running (11.9s), 00/16 VUs, 16 complete and 0 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/uwebsocket-js/binary-sync.txt
+++ b/results/vus-16/uwebsocket-js/binary-sync.txt
@@ -1,0 +1,143 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/binary-sync.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (08.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (09.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (10.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (11.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (12.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (13.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (14.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (15.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (16.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (17.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (18.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (19.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (20.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (21.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (22.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (23.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (24.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (25.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (26.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (27.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (28.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (29.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (30.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (31.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (32.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (33.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (34.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (35.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+time="2025-10-06T13:32:23+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
+
+
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 16      min=16         max=16
+    vus_max............................: 16      min=16         max=16
+
+    NETWORK
+    data_received......................: 7.2 MB  205 kB/s
+    data_sent..........................: 12 MB   341 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=5.22ms min=3.55ms med=5.56ms max=6.22ms p(90)=6.15ms p(95)=6.21ms
+    ws_msgs_received...................: 1194556 34129.443009/s
+    ws_msgs_sent.......................: 1194572 34129.900142/s
+    ws_sessions........................: 16      0.457133/s
+
+
+
+
+running (35.0s), 00/16 VUs, 0 complete and 16 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/uwebsocket-js/connection.txt
+++ b/results/vus-16/uwebsocket-js/connection.txt
@@ -1,0 +1,59 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/connection.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 8465 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 16756 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 24999 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 31244 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 38893 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 38981   7794.733031/s
+    checks_succeeded...................: 100.00% 38981 out of 38981
+    checks_failed......................: 0.00%   0 out of 38981
+
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=2.04ms min=503.37µs med=1.82ms max=103.17ms p(90)=2.67ms p(95)=3.11ms
+    iterations...............................: 38981  7794.733031/s
+    vus......................................: 16     min=16        max=16
+    vus_max..................................: 16     min=16        max=16
+
+    NETWORK
+    data_received............................: 7.1 MB 1.4 MB/s
+    data_sent................................: 7.8 MB 1.6 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=2ms    min=482.7µs  med=1.79ms max=103.02ms p(90)=2.63ms p(95)=3.06ms
+    ws_session_duration......................: avg=2.03ms min=495.95µs med=1.81ms max=103.15ms p(90)=2.66ms p(95)=3.09ms
+    ws_sessions..............................: 38981  7794.733031/s
+
+
+
+
+running (05.0s), 00/16 VUs, 38981 complete and 0 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/uwebsocket-js/json-async.txt
+++ b/results/vus-16/uwebsocket-js/json-async.txt
@@ -1,0 +1,66 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/json-async.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 03/16 VUs, 13 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 48      7.987757/s
+    checks_succeeded...................: 100.00% 48 out of 48
+    checks_failed......................: 0.00%   0 out of 48
+
+    ✓ expected ${this} to be a number
+    ✓ expected ${this} to equal +0
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=5.96s   min=5.85s  med=5.97s   max=6s      p(90)=6s     p(95)=6s     
+    iterations...............................: 16      2.662586/s
+    vus......................................: 3       min=3           max=16
+    vus_max..................................: 16      min=16          max=16
+
+    NETWORK
+    data_received............................: 29 MB   4.8 MB/s
+    data_sent................................: 35 MB   5.8 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=15.15ms min=3.36ms med=16.22ms max=25.78ms p(90)=22.3ms p(95)=23.18ms
+    ws_msgs_received.........................: 1600000 266258.581015/s
+    ws_msgs_sent.............................: 1600000 266258.581015/s
+    ws_session_duration......................: avg=5.96s   min=5.85s  med=5.97s   max=6s      p(90)=6s     p(95)=6s     
+    ws_sessions..............................: 16      2.662586/s
+
+
+
+
+running (06.0s), 00/16 VUs, 16 complete and 0 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/uwebsocket-js/json-sync.txt
+++ b/results/vus-16/uwebsocket-js/json-sync.txt
@@ -1,0 +1,143 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/json-sync.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (08.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (09.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (10.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (11.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (12.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (13.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (14.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (15.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (16.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (17.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (18.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (19.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (20.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (21.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (22.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (23.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (24.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (25.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (26.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (27.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (28.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (29.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (30.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (31.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (32.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (33.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (34.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (35.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+time="2025-10-06T13:31:28+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
+
+
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 16      min=16         max=16
+    vus_max............................: 16      min=16         max=16
+
+    NETWORK
+    data_received......................: 20 MB   572 kB/s
+    data_sent..........................: 25 MB   700 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=5.56ms min=3.74ms med=5.41ms max=6.82ms p(90)=6.79ms p(95)=6.81ms
+    ws_msgs_received...................: 1121558 32044.007075/s
+    ws_msgs_sent.......................: 1121573 32044.43564/s
+    ws_sessions........................: 16      0.457136/s
+
+
+
+
+running (35.0s), 00/16 VUs, 0 complete and 16 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/uwebsocket-js/plain-async.txt
+++ b/results/vus-16/uwebsocket-js/plain-async.txt
@@ -1,0 +1,80 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/plain-async.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (06.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (08.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (09.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (10.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (11.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 32      2.829246/s
+    checks_succeeded...................: 100.00% 32 out of 32
+    checks_failed......................: 0.00%   0 out of 32
+
+    ✓ expected ${this} to match /number\:\s[0-9]+/
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=11.19s  min=11.05s  med=11.22s  max=11.31s  p(90)=11.29s  p(95)=11.31s 
+    iterations...............................: 16      1.414623/s
+    vus......................................: 16      min=16          max=16
+    vus_max..................................: 16      min=16          max=16
+
+    NETWORK
+    data_received............................: 24 MB   2.1 MB/s
+    data_sent................................: 30 MB   2.7 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=20.89ms min=13.75ms med=19.37ms max=30.77ms p(90)=30.74ms p(95)=30.76ms
+    ws_msgs_received.........................: 1600000 141462.311832/s
+    ws_msgs_sent.............................: 1600000 141462.311832/s
+    ws_session_duration......................: avg=11.19s  min=11.05s  med=11.22s  max=11.31s  p(90)=11.29s  p(95)=11.31s 
+    ws_sessions..............................: 16      1.414623/s
+
+
+
+
+running (11.3s), 00/16 VUs, 16 complete and 0 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/uwebsocket-js/plain-sync.txt
+++ b/results/vus-16/uwebsocket-js/plain-sync.txt
@@ -1,0 +1,143 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/plain-sync.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (08.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (09.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (10.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (11.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (12.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (13.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (14.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (15.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (16.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (17.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (18.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (19.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (20.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (21.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (22.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (23.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (24.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (25.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (26.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (27.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (28.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (29.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (30.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (31.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (32.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (33.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (34.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (35.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+time="2025-10-06T13:30:28+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
+
+
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 16      min=16         max=16
+    vus_max............................: 16      min=16         max=16
+
+    NETWORK
+    data_received......................: 18 MB   523 kB/s
+    data_sent..........................: 23 MB   664 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=7.52ms min=6.29ms med=7.63ms max=8.46ms p(90)=8.39ms p(95)=8.42ms
+    ws_msgs_received...................: 1232960 35226.087967/s
+    ws_msgs_sent.......................: 1232976 35226.545093/s
+    ws_sessions........................: 16      0.457125/s
+
+
+
+
+running (35.0s), 00/16 VUs, 0 complete and 16 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/websocketpp/binary-async.txt
+++ b/results/vus-16/websocketpp/binary-async.txt
@@ -1,0 +1,63 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/binary-async.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 48      8.23268/s
+    checks_succeeded...................: 100.00% 48 out of 48
+    checks_failed......................: 0.00%   0 out of 48
+
+    ✓ expected ${this} to be a number
+    ✓ expected ${this} to equal +0
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=5.76s   min=5.57s  med=5.77s  max=5.82s   p(90)=5.82s   p(95)=5.82s  
+    iterations...............................: 16      2.744227/s
+    vus......................................: 16      min=16          max=16
+    vus_max..................................: 16      min=16          max=16
+
+    NETWORK
+    data_received............................: 9.6 MB  1.6 MB/s
+    data_sent................................: 16 MB   2.7 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=10.78ms min=4.15ms med=8.91ms max=18.67ms p(90)=17.27ms p(95)=18.16ms
+    ws_msgs_received.........................: 1600000 274422.674722/s
+    ws_msgs_sent.............................: 1600000 274422.674722/s
+    ws_session_duration......................: avg=5.76s   min=5.57s  med=5.77s  max=5.82s   p(90)=5.82s   p(95)=5.82s  
+    ws_sessions..............................: 16      2.744227/s
+
+
+
+
+running (05.8s), 00/16 VUs, 16 complete and 0 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/websocketpp/binary-sync.txt
+++ b/results/vus-16/websocketpp/binary-sync.txt
@@ -1,0 +1,143 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/binary-sync.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (08.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (09.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (10.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (11.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (12.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (13.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (14.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (15.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (16.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (17.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (18.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (19.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (20.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (21.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (22.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (23.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (24.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (25.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (26.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (27.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (28.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (29.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (30.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (31.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (32.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (33.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (34.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (35.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+time="2025-10-06T13:37:21+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
+
+
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 16      min=16         max=16
+    vus_max............................: 16      min=16         max=16
+
+    NETWORK
+    data_received......................: 7.6 MB  217 kB/s
+    data_sent..........................: 13 MB   362 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=5.44ms min=3.33ms med=5.91ms max=6.94ms p(90)=6.66ms p(95)=6.8ms
+    ws_msgs_received...................: 1267000 36198.696847/s
+    ws_msgs_sent.......................: 1267016 36199.153973/s
+    ws_sessions........................: 16      0.457126/s
+
+
+
+
+running (35.0s), 00/16 VUs, 0 complete and 16 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/websocketpp/connection.txt
+++ b/results/vus-16/websocketpp/connection.txt
@@ -1,0 +1,59 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/connection.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 6088 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 12735 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 19383 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 25742 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 32425 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 32481   6494.632196/s
+    checks_succeeded...................: 100.00% 32481 out of 32481
+    checks_failed......................: 0.00%   0 out of 32481
+
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=2.45ms min=648.2µs  med=2.26ms max=66.02ms p(90)=3ms    p(95)=3.42ms
+    iterations...............................: 32481  6494.632196/s
+    vus......................................: 16     min=16        max=16
+    vus_max..................................: 16     min=16        max=16
+
+    NETWORK
+    data_received............................: 5.1 MB 1.0 MB/s
+    data_sent................................: 6.5 MB 1.3 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=2.42ms min=625µs    med=2.22ms max=65.99ms p(90)=2.96ms p(95)=3.38ms
+    ws_session_duration......................: avg=2.44ms min=640.08µs med=2.24ms max=66.01ms p(90)=2.98ms p(95)=3.41ms
+    ws_sessions..............................: 32481  6494.632196/s
+
+
+
+
+running (05.0s), 00/16 VUs, 32481 complete and 0 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/websocketpp/json-async.txt
+++ b/results/vus-16/websocketpp/json-async.txt
@@ -1,0 +1,63 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/json-async.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 48      8.752659/s
+    checks_succeeded...................: 100.00% 48 out of 48
+    checks_failed......................: 0.00%   0 out of 48
+
+    ✓ expected ${this} to be a number
+    ✓ expected ${this} to equal +0
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=5.46s   min=5.43s  med=5.47s   max=5.48s   p(90)=5.48s   p(95)=5.48s
+    iterations...............................: 16      2.917553/s
+    vus......................................: 16      min=16          max=16
+    vus_max..................................: 16      min=16          max=16
+
+    NETWORK
+    data_received............................: 29 MB   5.2 MB/s
+    data_sent................................: 35 MB   6.4 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=22.05ms min=3.77ms med=27.72ms max=28.14ms p(90)=27.91ms p(95)=28ms 
+    ws_msgs_received.........................: 1600000 291755.287335/s
+    ws_msgs_sent.............................: 1600000 291755.287335/s
+    ws_session_duration......................: avg=5.46s   min=5.43s  med=5.47s   max=5.48s   p(90)=5.48s   p(95)=5.48s
+    ws_sessions..............................: 16      2.917553/s
+
+
+
+
+running (05.5s), 00/16 VUs, 16 complete and 0 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/websocketpp/json-sync.txt
+++ b/results/vus-16/websocketpp/json-sync.txt
@@ -1,0 +1,143 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/json-sync.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (08.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (09.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (10.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (11.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (12.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (13.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (14.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (15.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (16.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (17.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (18.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (19.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (20.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (21.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (22.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (23.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (24.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (25.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (26.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (27.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (28.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (29.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (30.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (31.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (32.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (33.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (34.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (35.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+time="2025-10-06T13:36:08+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
+
+
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 16      min=16         max=16
+    vus_max............................: 16      min=16         max=16
+
+    NETWORK
+    data_received......................: 22 MB   619 kB/s
+    data_sent..........................: 27 MB   758 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=6ms min=4.18ms med=6.08ms max=8.12ms p(90)=7.01ms p(95)=7.38ms
+    ws_msgs_received...................: 1213063 34657.213957/s
+    ws_msgs_sent.......................: 1213079 34657.671077/s
+    ws_sessions........................: 16      0.45712/s
+
+
+
+
+running (35.0s), 00/16 VUs, 0 complete and 16 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/websocketpp/plain-async.txt
+++ b/results/vus-16/websocketpp/plain-async.txt
@@ -1,0 +1,65 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/plain-async.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 6 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 06/16 VUs, 16 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 44      6.561532/s
+    checks_succeeded...................: 100.00% 44 out of 44
+    checks_failed......................: 0.00%   0 out of 44
+
+    ✓ expected ${this} to match /number\:\s[0-9]+/
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=4.27s  min=2.05s med=4.58s  max=5.69s   p(90)=5.56s   p(95)=5.63s  
+    iterations...............................: 22      3.280766/s
+    vus......................................: 6       min=6           max=16
+    vus_max..................................: 16      min=16          max=16
+
+    NETWORK
+    data_received............................: 33 MB   4.9 MB/s
+    data_sent................................: 42 MB   6.2 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=7.62ms min=1.6ms med=8.59ms max=15.89ms p(90)=13.65ms p(95)=15.27ms
+    ws_msgs_received.........................: 2200000 328076.601711/s
+    ws_msgs_sent.............................: 2200000 328076.601711/s
+    ws_session_duration......................: avg=4.27s  min=2.05s med=4.57s  max=5.69s   p(90)=5.56s   p(95)=5.63s  
+    ws_sessions..............................: 22      3.280766/s
+
+
+
+
+running (06.7s), 00/16 VUs, 22 complete and 0 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-16/websocketpp/plain-sync.txt
+++ b/results/vus-16/websocketpp/plain-sync.txt
@@ -1,0 +1,143 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/plain-sync.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 16 max VUs, 35s max duration (incl. graceful stop):
+              * default: 16 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 16 VUs  1.0s/5s
+
+running (02.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 16 VUs  2.0s/5s
+
+running (03.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 16 VUs  3.0s/5s
+
+running (04.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 16 VUs  4.0s/5s
+
+running (05.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 16 VUs  5.0s/5s
+
+running (06.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (07.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (08.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (09.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (10.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (11.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (12.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (13.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (14.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (15.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (16.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (17.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (18.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (19.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (20.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (21.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (22.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (23.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (24.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (25.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (26.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (27.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (28.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (29.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (30.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (31.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (32.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (33.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (34.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+
+running (35.0s), 16/16 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 16 VUs  5s
+time="2025-10-06T13:34:54+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
+
+
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 16      min=16         max=16
+    vus_max............................: 16      min=16         max=16
+
+    NETWORK
+    data_received......................: 19 MB   537 kB/s
+    data_sent..........................: 24 MB   682 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=4.91ms min=2.04ms med=5.24ms max=7.99ms p(90)=7.07ms p(95)=7.69ms
+    ws_msgs_received...................: 1265660 36160.075718/s
+    ws_msgs_sent.......................: 1265676 36160.53284/s
+    ws_sessions........................: 16      0.457122/s
+
+
+
+
+running (35.0s), 00/16 VUs, 0 complete and 16 interrupted iterations
+default ✓ [ 100% ] 16 VUs  5s

--- a/results/vus-64/bun-websocket/binary-async.txt
+++ b/results/vus-64/bun-websocket/binary-async.txt
@@ -1,16 +1,16 @@
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ./benchmarks/binary-async.js
-     output: -
+     execution: local
+        script: ./benchmarks/binary-async.js
+        output: -
 
-  scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
-           * default: 64 looping VUs for 5s (gracefulStop: 30s)
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
 
 
 running (01.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
@@ -20,10 +20,10 @@ running (02.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default   [  39% ] 64 VUs  2.0s/5s
 
 running (03.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  59% ] 64 VUs  3.0s/5s
+default   [  60% ] 64 VUs  3.0s/5s
 
 running (04.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  79% ] 64 VUs  4.0s/5s
+default   [  80% ] 64 VUs  4.0s/5s
 
 running (05.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default   [ 100% ] 64 VUs  5.0s/5s
@@ -49,26 +49,95 @@ default ↓ [ 100% ] 64 VUs  5s
 running (12.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (13.0s), 63/64 VUs, 1 complete and 0 interrupted iterations
+running (13.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-     ✓ expected ${this} to be a number
-     ✓ expected ${this} to equal +0
-     ✓ status is 101
+running (14.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
 
-     checks................: 100.00% ✓ 192           ✗ 0   
-     data_received.........: 115 MB  8.4 MB/s
-     data_sent.............: 64 MB   4.7 MB/s
-     iteration_duration....: avg=13.54s   min=12.65s med=13.59s   max=13.69s   p(90)=13.68s   p(95)=13.69s  
-     iterations............: 64      4.673171/s
-     vus...................: 63      min=63          max=64
-     vus_max...............: 64      min=64          max=64
-     ws_connecting.........: avg=104.21ms min=3.34ms med=110.44ms max=112.75ms p(90)=112.51ms p(95)=112.55ms
-     ws_msgs_received......: 6400000 467317.123974/s
-     ws_msgs_sent..........: 6400000 467317.123974/s
-     ws_session_duration...: avg=13.54s   min=12.64s med=13.59s   max=13.69s   p(90)=13.68s   p(95)=13.69s  
-     ws_sessions...........: 64      4.673171/s
+running (15.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (16.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (17.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (18.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (19.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (20.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (21.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (22.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (23.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (24.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (25.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (26.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (27.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (28.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (29.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (30.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (31.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (32.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (33.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (34.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (35.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+time="2025-09-30T19:22:06+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
 
 
-running (13.7s), 00/64 VUs, 64 complete and 0 interrupted iterations
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 64      min=64          max=64
+    vus_max............................: 64      min=64          max=64
+
+    NETWORK
+    data_received......................: 19 MB   529 kB/s
+    data_sent..........................: 64 MB   1.8 MB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=29.16ms min=13.33ms med=36.46ms max=37.39ms p(90)=37.15ms p(95)=37.27ms
+    ws_msgs_received...................: 1020441 29151.62995/s
+    ws_msgs_sent.......................: 6399975 182832.425286/s
+    ws_sessions........................: 64      1.828331/s
+
+
+
+
+running (35.0s), 00/64 VUs, 0 complete and 64 interrupted iterations
 default ✓ [ 100% ] 64 VUs  5s

--- a/results/vus-64/bun-websocket/binary-sync.txt
+++ b/results/vus-64/bun-websocket/binary-sync.txt
@@ -1,16 +1,16 @@
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ./benchmarks/binary-sync.js
-     output: -
+     execution: local
+        script: ./benchmarks/binary-sync.js
+        output: -
 
-  scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
-           * default: 64 looping VUs for 5s (gracefulStop: 30s)
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
 
 
 running (01.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
@@ -117,17 +117,26 @@ default ↓ [ 100% ] 64 VUs  5s
 
 running (35.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
+time="2025-09-30T19:21:15+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
 
-     ✓ status is 101
 
-     data_received......: 44 MB   1.3 MB/s
-     data_sent..........: 24 MB   698 kB/s
-     vus................: 64      min=64         max=64
-     vus_max............: 64      min=64         max=64
-     ws_connecting......: avg=20.08ms min=2.69ms med=6.23ms max=59ms p(90)=54.06ms p(95)=57.18ms
-     ws_msgs_received...: 2442735 69794.434565/s
-     ws_msgs_sent.......: 2442796 69796.177472/s
-     ws_sessions........: 64      1.828624/s
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 64     min=64         max=64
+    vus_max............................: 64     min=64         max=64
+
+    NETWORK
+    data_received......................: 15 MB  420 kB/s
+    data_sent..........................: 8.2 MB 234 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=17.45ms min=6.94ms med=14.2ms max=31.06ms p(90)=30.6ms p(95)=30.65ms
+    ws_msgs_received...................: 816311 23322.161246/s
+    ws_msgs_sent.......................: 816375 23323.989738/s
+    ws_sessions........................: 64     1.828492/s
+
+
 
 
 running (35.0s), 00/64 VUs, 0 complete and 64 interrupted iterations

--- a/results/vus-64/bun-websocket/connection.txt
+++ b/results/vus-64/bun-websocket/connection.txt
@@ -1,46 +1,59 @@
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ./benchmarks/connection.js
-     output: -
+     execution: local
+        script: ./benchmarks/connection.js
+        output: -
 
-  scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
-           * default: 64 looping VUs for 5s (gracefulStop: 30s)
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
 
 
-running (01.0s), 64/64 VUs, 11229 complete and 0 interrupted iterations
+running (01.0s), 64/64 VUs, 8880 complete and 0 interrupted iterations
 default   [  20% ] 64 VUs  1.0s/5s
 
-running (02.0s), 64/64 VUs, 24626 complete and 0 interrupted iterations
+running (02.0s), 64/64 VUs, 15518 complete and 0 interrupted iterations
 default   [  40% ] 64 VUs  2.0s/5s
 
-running (03.0s), 64/64 VUs, 37889 complete and 0 interrupted iterations
+running (03.0s), 64/64 VUs, 23875 complete and 0 interrupted iterations
 default   [  60% ] 64 VUs  3.0s/5s
 
-running (04.0s), 64/64 VUs, 51608 complete and 0 interrupted iterations
+running (04.0s), 64/64 VUs, 31777 complete and 0 interrupted iterations
 default   [  80% ] 64 VUs  4.0s/5s
 
-running (05.0s), 64/64 VUs, 65320 complete and 0 interrupted iterations
+running (05.0s), 64/64 VUs, 39841 complete and 0 interrupted iterations
 default   [ 100% ] 64 VUs  5.0s/5s
 
-     ✓ status is 101
 
-     checks................: 100.00% ✓ 65391       ✗ 0   
-     data_received.........: 11 MB   2.2 MB/s
-     data_sent.............: 14 MB   2.8 MB/s
-     iteration_duration....: avg=4.88ms min=602.42µs med=4.48ms max=100.77ms p(90)=6.99ms p(95)=8.09ms
-     iterations............: 65391   13069.55048/s
-     vus...................: 64      min=64        max=64
-     vus_max...............: 64      min=64        max=64
-     ws_connecting.........: avg=4.79ms min=525.68µs med=4.39ms max=100.63ms p(90)=6.87ms p(95)=7.97ms
-     ws_session_duration...: avg=4.84ms min=567.12µs med=4.44ms max=100.71ms p(90)=6.94ms p(95)=8.04ms
-     ws_sessions...........: 65391   13069.55048/s
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 39949   7979.35343/s
+    checks_succeeded...................: 100.00% 39949 out of 39949
+    checks_failed......................: 0.00%   0 out of 39949
+
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=8.01ms min=981.16µs med=7.46ms max=57.45ms p(90)=11.4ms  p(95)=13.22ms
+    iterations...............................: 39949  7979.35343/s
+    vus......................................: 64     min=64       max=64
+    vus_max..................................: 64     min=64       max=64
+
+    NETWORK
+    data_received............................: 6.6 MB 1.3 MB/s
+    data_sent................................: 8.0 MB 1.6 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=7.97ms min=906.91µs med=7.43ms max=57.37ms p(90)=11.36ms p(95)=13.18ms
+    ws_session_duration......................: avg=7.99ms min=953.45µs med=7.45ms max=57.42ms p(90)=11.38ms p(95)=13.2ms 
+    ws_sessions..............................: 39949  7979.35343/s
 
 
-running (05.0s), 00/64 VUs, 65391 complete and 0 interrupted iterations
+
+
+running (05.0s), 00/64 VUs, 39949 complete and 0 interrupted iterations
 default ✓ [ 100% ] 64 VUs  5s

--- a/results/vus-64/bun-websocket/json-async.txt
+++ b/results/vus-64/bun-websocket/json-async.txt
@@ -1,32 +1,32 @@
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ./benchmarks/json-async.js
-     output: -
+     execution: local
+        script: ./benchmarks/json-async.js
+        output: -
 
-  scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
-           * default: 64 looping VUs for 5s (gracefulStop: 30s)
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
 
 
 running (01.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  19% ] 64 VUs  1.0s/5s
+default   [  20% ] 64 VUs  1.0s/5s
 
 running (02.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  39% ] 64 VUs  2.0s/5s
+default   [  40% ] 64 VUs  2.0s/5s
 
 running (03.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default   [  60% ] 64 VUs  3.0s/5s
 
 running (04.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  79% ] 64 VUs  4.0s/5s
+default   [  80% ] 64 VUs  4.0s/5s
 
 running (05.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  99% ] 64 VUs  5.0s/5s
+default   [ 100% ] 64 VUs  5.0s/5s
 
 running (06.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
@@ -40,26 +40,104 @@ default ↓ [ 100% ] 64 VUs  5s
 running (09.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (10.0s), 62/64 VUs, 2 complete and 0 interrupted iterations
+running (10.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-     ✓ expected ${this} to be a number
-     ✓ expected ${this} to equal +0
-     ✓ status is 101
+running (11.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
 
-     checks................: 100.00% ✓ 192           ✗ 0   
-     data_received.........: 115 MB  11 MB/s
-     data_sent.............: 140 MB  13 MB/s
-     iteration_duration....: avg=10.35s  min=9.88s  med=10.4s   max=10.47s   p(90)=10.46s  p(95)=10.46s  
-     iterations............: 64      6.111684/s
-     vus...................: 62      min=62          max=64
-     vus_max...............: 64      min=64          max=64
-     ws_connecting.........: avg=46.81ms min=3.17ms med=10.53ms max=165.33ms p(90)=162.5ms p(95)=163.53ms
-     ws_msgs_received......: 6400000 611168.371646/s
-     ws_msgs_sent..........: 6400000 611168.371646/s
-     ws_session_duration...: avg=10.35s  min=9.88s  med=10.4s   max=10.47s   p(90)=10.46s  p(95)=10.46s  
-     ws_sessions...........: 64      6.111684/s
+running (12.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (13.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (14.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (15.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (16.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (17.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (18.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (19.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (20.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (21.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (22.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (23.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (24.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (25.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (26.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (27.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (28.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (29.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (30.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (31.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (32.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (33.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (34.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (35.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+time="2025-09-30T19:20:23+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
 
 
-running (10.5s), 00/64 VUs, 64 complete and 0 interrupted iterations
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 64      min=64          max=64
+    vus_max............................: 64      min=64          max=64
+
+    NETWORK
+    data_received......................: 66 MB   1.9 MB/s
+    data_sent..........................: 140 MB  4.0 MB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=51.59ms min=8.39ms med=64.35ms max=65.26ms p(90)=64.72ms p(95)=64.85ms
+    ws_msgs_received...................: 3675018 104983.872842/s
+    ws_msgs_sent.......................: 6400000 182828.161982/s
+    ws_sessions........................: 64      1.828282/s
+
+
+
+
+running (35.0s), 00/64 VUs, 0 complete and 64 interrupted iterations
 default ✓ [ 100% ] 64 VUs  5s

--- a/results/vus-64/bun-websocket/json-sync.txt
+++ b/results/vus-64/bun-websocket/json-sync.txt
@@ -1,16 +1,16 @@
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ./benchmarks/json-sync.js
-     output: -
+     execution: local
+        script: ./benchmarks/json-sync.js
+        output: -
 
-  scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
-           * default: 64 looping VUs for 5s (gracefulStop: 30s)
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
 
 
 running (01.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
@@ -55,7 +55,7 @@ default ↓ [ 100% ] 64 VUs  5s
 running (14.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (15.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (15.1s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
 running (16.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
@@ -117,17 +117,26 @@ default ↓ [ 100% ] 64 VUs  5s
 
 running (35.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
+time="2025-09-30T19:19:31+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
 
-     ✓ status is 101
 
-     data_received......: 47 MB   1.3 MB/s
-     data_sent..........: 58 MB   1.6 MB/s
-     vus................: 64      min=64         max=64
-     vus_max............: 64      min=64         max=64
-     ws_connecting......: avg=61.52ms min=22.71ms med=57.05ms max=75.13ms p(90)=74.1ms p(95)=74.51ms
-     ws_msgs_received...: 2646205 75606.357558/s
-     ws_msgs_sent.......: 2646268 75608.157569/s
-     ws_sessions........: 64      1.828584/s
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 64     min=64         max=64
+    vus_max............................: 64     min=64         max=64
+
+    NETWORK
+    data_received......................: 7.8 MB 224 kB/s
+    data_sent..........................: 9.7 MB 277 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=22.79ms min=6.59ms med=24.58ms max=28.81ms p(90)=27.46ms p(95)=28.39ms
+    ws_msgs_received...................: 464936 13282.81436/s
+    ws_msgs_sent.......................: 465000 13284.642784/s
+    ws_sessions........................: 64     1.828424/s
+
+
 
 
 running (35.0s), 00/64 VUs, 0 complete and 64 interrupted iterations

--- a/results/vus-64/bun-websocket/plain-async.txt
+++ b/results/vus-64/bun-websocket/plain-async.txt
@@ -1,32 +1,32 @@
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ./benchmarks/plain-async.js
-     output: -
+     execution: local
+        script: ./benchmarks/plain-async.js
+        output: -
 
-  scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
-           * default: 64 looping VUs for 5s (gracefulStop: 30s)
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
 
 
 running (01.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  19% ] 64 VUs  1.0s/5s
+default   [  20% ] 64 VUs  1.0s/5s
 
 running (02.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  39% ] 64 VUs  2.0s/5s
+default   [  40% ] 64 VUs  2.0s/5s
 
 running (03.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  59% ] 64 VUs  3.0s/5s
+default   [  60% ] 64 VUs  3.0s/5s
 
 running (04.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  79% ] 64 VUs  4.0s/5s
+default   [  80% ] 64 VUs  4.0s/5s
 
 running (05.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  99% ] 64 VUs  5.0s/5s
+default   [ 100% ] 64 VUs  5.0s/5s
 
 running (06.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
@@ -34,25 +34,107 @@ default ↓ [ 100% ] 64 VUs  5s
 running (07.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (08.0s), 10/64 VUs, 54 complete and 0 interrupted iterations
+running (08.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-     ✓ expected ${this} to match /number\:\s[0-9]+/
-     ✓ status is 101
+running (09.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
 
-     checks................: 100.00% ✓ 128          ✗ 0   
-     data_received.........: 95 MB   12 MB/s
-     data_sent.............: 121 MB  15 MB/s
-     iteration_duration....: avg=7.86s   min=7.23s  med=7.91s   max=7.97s   p(90)=7.97s   p(95)=7.97s  
-     iterations............: 64      8.023969/s
-     vus...................: 10      min=10         max=64
-     vus_max...............: 64      min=64         max=64
-     ws_connecting.........: avg=39.26ms min=2.42ms med=39.18ms max=81.44ms p(90)=74.98ms p(95)=76.35ms
-     ws_msgs_received......: 6400000 802396.90006/s
-     ws_msgs_sent..........: 6400000 802396.90006/s
-     ws_session_duration...: avg=7.86s   min=7.22s  med=7.91s   max=7.97s   p(90)=7.97s   p(95)=7.97s  
-     ws_sessions...........: 64      8.023969/s
+running (10.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (11.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (12.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (13.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (14.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (15.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (16.0s), 61/64 VUs, 3 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (17.0s), 60/64 VUs, 4 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (18.0s), 60/64 VUs, 4 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (19.0s), 60/64 VUs, 4 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (20.0s), 60/64 VUs, 4 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (21.0s), 59/64 VUs, 5 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (22.0s), 59/64 VUs, 5 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (23.0s), 59/64 VUs, 5 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (24.0s), 58/64 VUs, 6 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (25.0s), 56/64 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (26.0s), 56/64 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (27.0s), 54/64 VUs, 10 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (28.0s), 53/64 VUs, 11 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (29.0s), 50/64 VUs, 14 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (30.0s), 43/64 VUs, 21 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (31.0s), 27/64 VUs, 37 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
 
 
-running (08.0s), 00/64 VUs, 64 complete and 0 interrupted iterations
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 128     4.045666/s
+    checks_succeeded...................: 100.00% 128 out of 128
+    checks_failed......................: 0.00%   0 out of 128
+
+    ✓ expected ${this} to match /number\:\s[0-9]+/
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=29.21s  min=15.48s med=30.81s  max=31.63s  p(90)=31.61s  p(95)=31.63s 
+    iterations...............................: 64      2.022833/s
+    vus......................................: 27      min=27          max=64
+    vus_max..................................: 64      min=64          max=64
+
+    NETWORK
+    data_received............................: 95 MB   3.0 MB/s
+    data_sent................................: 121 MB  3.8 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=35.28ms min=6.38ms med=45.75ms max=47.44ms p(90)=46.58ms p(95)=46.68ms
+    ws_msgs_received.........................: 6400000 202283.323586/s
+    ws_msgs_sent.............................: 6400000 202283.323586/s
+    ws_session_duration......................: avg=29.21s  min=15.48s med=30.81s  max=31.63s  p(90)=31.61s  p(95)=31.63s 
+    ws_sessions..............................: 64      2.022833/s
+
+
+
+
+running (31.6s), 00/64 VUs, 64 complete and 0 interrupted iterations
 default ✓ [ 100% ] 64 VUs  5s

--- a/results/vus-64/bun-websocket/plain-sync.txt
+++ b/results/vus-64/bun-websocket/plain-sync.txt
@@ -1,133 +1,142 @@
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ./benchmarks/plain-sync.js
-     output: -
+     execution: local
+        script: ./benchmarks/plain-sync.js
+        output: -
 
-  scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
-           * default: 64 looping VUs for 5s (gracefulStop: 30s)
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
 
 
-running (01.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  20% ] 64 VUs  1.0s/5s
+running (00.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [  18% ] 64 VUs  0.9s/5s
 
-running (02.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  40% ] 64 VUs  2.0s/5s
+running (01.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [  38% ] 64 VUs  1.9s/5s
 
-running (03.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  60% ] 64 VUs  3.0s/5s
+running (02.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [  58% ] 64 VUs  2.9s/5s
 
-running (04.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  80% ] 64 VUs  4.0s/5s
+running (03.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [  78% ] 64 VUs  3.9s/5s
 
-running (05.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [ 100% ] 64 VUs  5.0s/5s
+running (04.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [  98% ] 64 VUs  4.9s/5s
 
-running (06.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (05.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (07.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (06.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (08.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (07.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (09.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (08.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (10.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (09.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (11.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (10.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (12.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (11.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (13.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (12.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (14.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (13.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (15.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (14.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (16.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (15.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (17.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (16.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (18.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (17.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (19.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (18.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (20.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (19.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (21.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (20.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (22.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (21.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (23.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (22.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (24.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (23.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (25.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (24.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (26.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (25.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (27.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (26.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (28.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (27.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (29.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (28.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (30.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (29.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (31.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (30.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (32.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (31.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (33.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (32.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (34.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (33.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (35.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (34.9s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
+time="2025-09-30T19:17:48+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
 
-     ✓ status is 101
 
-     data_received......: 40 MB   1.2 MB/s
-     data_sent..........: 51 MB   1.5 MB/s
-     vus................: 64      min=64         max=64
-     vus_max............: 64      min=64         max=64
-     ws_connecting......: avg=15.94ms min=2.1ms med=2.86ms max=67.65ms p(90)=67.33ms p(95)=67.45ms
-     ws_msgs_received...: 2736205 78172.619488/s
-     ws_msgs_sent.......: 2736266 78174.362241/s
-     ws_sessions........: 64      1.828462/s
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 64      min=64         max=64
+    vus_max............................: 64      min=64         max=64
+
+    NETWORK
+    data_received......................: 15 MB   434 kB/s
+    data_sent..........................: 19 MB   555 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=18.34ms min=5.33ms med=22.23ms max=25.26ms p(90)=23.96ms p(95)=24.19ms
+    ws_msgs_received...................: 1058699 30246.031572/s
+    ws_msgs_sent.......................: 1058762 30247.831423/s
+    ws_sessions........................: 64      1.82842/s
+
+
 
 
 running (35.0s), 00/64 VUs, 0 complete and 64 interrupted iterations

--- a/results/vus-64/fasthttp-websocket/binary-async.txt
+++ b/results/vus-64/fasthttp-websocket/binary-async.txt
@@ -1,32 +1,32 @@
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ./benchmarks/binary-async.js
-     output: -
+     execution: local
+        script: ./benchmarks/binary-async.js
+        output: -
 
-  scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
-           * default: 64 looping VUs for 5s (gracefulStop: 30s)
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
 
 
 running (01.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  19% ] 64 VUs  1.0s/5s
+default   [  20% ] 64 VUs  1.0s/5s
 
 running (02.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  39% ] 64 VUs  2.0s/5s
+default   [  40% ] 64 VUs  2.0s/5s
 
 running (03.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  59% ] 64 VUs  3.0s/5s
+default   [  60% ] 64 VUs  3.0s/5s
 
 running (04.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default   [  80% ] 64 VUs  4.0s/5s
 
 running (05.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  99% ] 64 VUs  5.0s/5s
+default   [ 100% ] 64 VUs  5.0s/5s
 
 running (06.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
@@ -52,26 +52,92 @@ default ↓ [ 100% ] 64 VUs  5s
 running (13.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (14.0s), 61/64 VUs, 3 complete and 0 interrupted iterations
+running (14.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-     ✓ expected ${this} to be a number
-     ✓ expected ${this} to equal +0
-     ✓ status is 101
+running (15.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
 
-     checks................: 100.00% ✓ 192           ✗ 0   
-     data_received.........: 38 MB   2.6 MB/s
-     data_sent.............: 64 MB   4.4 MB/s
-     iteration_duration....: avg=14.34s  min=13.64s med=14.4s   max=14.53s  p(90)=14.51s  p(95)=14.52s
-     iterations............: 64      4.402506/s
-     vus...................: 61      min=61          max=64
-     vus_max...............: 64      min=64          max=64
-     ws_connecting.........: avg=50.31ms min=1.96ms med=47.61ms max=82.87ms p(90)=80.03ms p(95)=80.6ms
-     ws_msgs_received......: 6400000 440250.603802/s
-     ws_msgs_sent..........: 6400000 440250.603802/s
-     ws_session_duration...: avg=14.34s  min=13.64s med=14.4s   max=14.53s  p(90)=14.51s  p(95)=14.52s
-     ws_sessions...........: 64      4.402506/s
+running (16.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (17.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (18.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (19.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (20.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (21.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (22.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (23.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (24.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (25.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (26.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (27.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (28.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (29.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (30.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (31.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (32.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (33.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (34.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (35.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+time="2025-09-30T19:04:25+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
 
 
-running (14.5s), 00/64 VUs, 64 complete and 0 interrupted iterations
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 64      min=64          max=64
+    vus_max............................: 64      min=64          max=64
+
+    NETWORK
+    data_received......................: 9.0 MB  256 kB/s
+    data_sent..........................: 64 MB   1.8 MB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=33.98ms min=4.9ms med=41.92ms max=43.96ms p(90)=43.15ms p(95)=43.26ms
+    ws_msgs_received...................: 1468219 41938.362488/s
+    ws_msgs_sent.......................: 6400000 182810.275526/s
+    ws_sessions........................: 64      1.828103/s
+
+
+
+
+running (35.0s), 00/64 VUs, 0 complete and 64 interrupted iterations
 default ✓ [ 100% ] 64 VUs  5s

--- a/results/vus-64/fasthttp-websocket/binary-sync.txt
+++ b/results/vus-64/fasthttp-websocket/binary-sync.txt
@@ -1,133 +1,142 @@
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ./benchmarks/binary-sync.js
-     output: -
+     execution: local
+        script: ./benchmarks/binary-sync.js
+        output: -
 
-  scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
-           * default: 64 looping VUs for 5s (gracefulStop: 30s)
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
 
 
-running (01.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  20% ] 64 VUs  1.0s/5s
+running (00.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [  11% ] 64 VUs  0.6s/5s
 
-running (02.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  40% ] 64 VUs  2.0s/5s
+running (01.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [  31% ] 64 VUs  1.6s/5s
 
-running (03.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  60% ] 64 VUs  3.0s/5s
+running (02.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [  51% ] 64 VUs  2.6s/5s
 
-running (04.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  80% ] 64 VUs  4.0s/5s
+running (03.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [  71% ] 64 VUs  3.6s/5s
 
-running (05.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [ 100% ] 64 VUs  5.0s/5s
+running (04.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [  91% ] 64 VUs  4.6s/5s
 
-running (06.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (05.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (07.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (06.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (08.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (07.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (09.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (08.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (10.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (09.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (11.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (10.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (12.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (11.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (13.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (12.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (14.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (13.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (15.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (14.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (16.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (15.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (17.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (16.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (18.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (17.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (19.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (18.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (20.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (19.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (21.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (20.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (22.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (21.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (23.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (22.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (24.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (23.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (25.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (24.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (26.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (25.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (27.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (26.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (28.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (27.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (29.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (28.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (30.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (29.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (31.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (30.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (32.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (31.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (33.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (32.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (34.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (33.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (35.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (34.6s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
+time="2025-09-30T19:03:44+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
 
-     ✓ status is 101
 
-     data_received......: 14 MB   410 kB/s
-     data_sent..........: 24 MB   683 kB/s
-     vus................: 64      min=64         max=64
-     vus_max............: 64      min=64         max=64
-     ws_connecting......: avg=22.29ms min=2.24ms med=5.73ms max=84.44ms p(90)=83.75ms p(95)=83.88ms
-     ws_msgs_received...: 2387525 68214.604466/s
-     ws_msgs_sent.......: 2387589 68216.433027/s
-     ws_sessions........: 64      1.828561/s
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 64     min=64         max=64
+    vus_max............................: 64     min=64         max=64
+
+    NETWORK
+    data_received......................: 4.8 MB 137 kB/s
+    data_sent..........................: 8.0 MB 229 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=118.84ms min=5.99ms med=129.17ms max=238.55ms p(90)=223.26ms p(95)=227.39ms
+    ws_msgs_received...................: 798335 22808.179478/s
+    ws_msgs_sent.......................: 798398 22809.979368/s
+    ws_sessions........................: 64     1.82846/s
+
+
 
 
 running (35.0s), 00/64 VUs, 0 complete and 64 interrupted iterations

--- a/results/vus-64/fasthttp-websocket/connection.txt
+++ b/results/vus-64/fasthttp-websocket/connection.txt
@@ -1,46 +1,59 @@
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ./benchmarks/connection.js
-     output: -
+     execution: local
+        script: ./benchmarks/connection.js
+        output: -
 
-  scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
-           * default: 64 looping VUs for 5s (gracefulStop: 30s)
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
 
 
-running (01.0s), 64/64 VUs, 12461 complete and 0 interrupted iterations
+running (01.0s), 64/64 VUs, 8997 complete and 0 interrupted iterations
 default   [  20% ] 64 VUs  1.0s/5s
 
-running (02.0s), 64/64 VUs, 22791 complete and 0 interrupted iterations
+running (02.0s), 64/64 VUs, 17310 complete and 0 interrupted iterations
 default   [  40% ] 64 VUs  2.0s/5s
 
-running (03.0s), 64/64 VUs, 35701 complete and 0 interrupted iterations
+running (03.0s), 64/64 VUs, 26282 complete and 0 interrupted iterations
 default   [  60% ] 64 VUs  3.0s/5s
 
-running (04.0s), 64/64 VUs, 47899 complete and 0 interrupted iterations
+running (04.0s), 64/64 VUs, 34963 complete and 0 interrupted iterations
 default   [  80% ] 64 VUs  4.0s/5s
 
-running (05.0s), 64/64 VUs, 57567 complete and 0 interrupted iterations
+running (05.0s), 64/64 VUs, 43246 complete and 0 interrupted iterations
 default   [ 100% ] 64 VUs  5.0s/5s
 
-     ✓ status is 101
 
-     checks................: 100.00% ✓ 57668        ✗ 0   
-     data_received.........: 11 MB   2.1 MB/s
-     data_sent.............: 12 MB   2.4 MB/s
-     iteration_duration....: avg=5.54ms min=552.2µs  med=5.04ms max=82.89ms p(90)=8.44ms p(95)=9.85ms
-     iterations............: 57668   11524.364692/s
-     vus...................: 64      min=64         max=64
-     vus_max...............: 64      min=64         max=64
-     ws_connecting.........: avg=5.44ms min=475.44µs med=4.94ms max=82.83ms p(90)=8.3ms  p(95)=9.7ms 
-     ws_session_duration...: avg=5.5ms  min=529.05µs med=5ms    max=82.86ms p(90)=8.39ms p(95)=9.8ms 
-     ws_sessions...........: 57668   11524.364692/s
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 43353   8663.170465/s
+    checks_succeeded...................: 100.00% 43353 out of 43353
+    checks_failed......................: 0.00%   0 out of 43353
+
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=7.38ms min=469.45µs med=7.05ms max=32.53ms p(90)=10.13ms p(95)=11.44ms
+    iterations...............................: 43353  8663.170465/s
+    vus......................................: 64     min=64        max=64
+    vus_max..................................: 64     min=64        max=64
+
+    NETWORK
+    data_received............................: 8.0 MB 1.6 MB/s
+    data_sent................................: 8.7 MB 1.7 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=7.34ms min=442.91µs med=7.01ms max=32.5ms  p(90)=10.1ms  p(95)=11.4ms 
+    ws_session_duration......................: avg=7.36ms min=460.12µs med=7.03ms max=32.51ms p(90)=10.12ms p(95)=11.42ms
+    ws_sessions..............................: 43353  8663.170465/s
 
 
-running (05.0s), 00/64 VUs, 57668 complete and 0 interrupted iterations
+
+
+running (05.0s), 00/64 VUs, 43353 complete and 0 interrupted iterations
 default ✓ [ 100% ] 64 VUs  5s

--- a/results/vus-64/fasthttp-websocket/json-async.txt
+++ b/results/vus-64/fasthttp-websocket/json-async.txt
@@ -1,26 +1,26 @@
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ./benchmarks/json-async.js
-     output: -
+     execution: local
+        script: ./benchmarks/json-async.js
+        output: -
 
-  scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
-           * default: 64 looping VUs for 5s (gracefulStop: 30s)
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
 
 
 running (01.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  19% ] 64 VUs  1.0s/5s
+default   [  20% ] 64 VUs  1.0s/5s
 
 running (02.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  39% ] 64 VUs  2.0s/5s
+default   [  40% ] 64 VUs  2.0s/5s
 
 running (03.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  59% ] 64 VUs  3.0s/5s
+default   [  60% ] 64 VUs  3.0s/5s
 
 running (04.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default   [  79% ] 64 VUs  4.0s/5s
@@ -46,26 +46,98 @@ default ↓ [ 100% ] 64 VUs  5s
 running (11.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (12.0s), 63/64 VUs, 1 complete and 0 interrupted iterations
+running (12.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-     ✓ expected ${this} to be a number
-     ✓ expected ${this} to equal +0
-     ✓ status is 101
+running (13.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
 
-     checks................: 100.00% ✓ 192           ✗ 0   
-     data_received.........: 115 MB  9.1 MB/s
-     data_sent.............: 140 MB  11 MB/s
-     iteration_duration....: avg=12.44s  min=11.88s  med=12.51s  max=12.59s   p(90)=12.57s   p(95)=12.58s  
-     iterations............: 64      5.08247/s
-     vus...................: 63      min=63          max=64
-     vus_max...............: 64      min=64          max=64
-     ws_connecting.........: avg=94.94ms min=89.53ms med=91.97ms max=127.47ms p(90)=102.14ms p(95)=102.28ms
-     ws_msgs_received......: 6400000 508246.997076/s
-     ws_msgs_sent..........: 6400000 508246.997076/s
-     ws_session_duration...: avg=12.44s  min=11.88s  med=12.51s  max=12.59s   p(90)=12.57s   p(95)=12.58s  
-     ws_sessions...........: 64      5.08247/s
+running (14.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (15.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (16.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (17.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (18.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (19.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (20.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (21.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (22.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (23.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (24.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (25.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (26.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (27.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (28.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (29.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (30.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (31.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (32.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (33.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (34.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (35.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+time="2025-09-30T19:03:02+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
 
 
-running (12.6s), 00/64 VUs, 64 complete and 0 interrupted iterations
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 64      min=64          max=64
+    vus_max............................: 64      min=64          max=64
+
+    NETWORK
+    data_received......................: 54 MB   1.6 MB/s
+    data_sent..........................: 140 MB  4.0 MB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=35.52ms min=4.98ms med=35.17ms max=99.29ms p(90)=58.7ms p(95)=72.14ms
+    ws_msgs_received...................: 3063098 87509.724896/s
+    ws_msgs_sent.......................: 6400000 182841.763253/s
+    ws_sessions........................: 64      1.828418/s
+
+
+
+
+running (35.0s), 00/64 VUs, 0 complete and 64 interrupted iterations
 default ✓ [ 100% ] 64 VUs  5s

--- a/results/vus-64/fasthttp-websocket/json-sync.txt
+++ b/results/vus-64/fasthttp-websocket/json-sync.txt
@@ -1,16 +1,16 @@
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ./benchmarks/json-sync.js
-     output: -
+     execution: local
+        script: ./benchmarks/json-sync.js
+        output: -
 
-  scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
-           * default: 64 looping VUs for 5s (gracefulStop: 30s)
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
 
 
 running (01.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
@@ -117,17 +117,26 @@ default ↓ [ 100% ] 64 VUs  5s
 
 running (35.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
+time="2025-09-30T19:02:21+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
 
-     ✓ status is 101
 
-     data_received......: 44 MB   1.3 MB/s
-     data_sent..........: 54 MB   1.5 MB/s
-     vus................: 64      min=64         max=64
-     vus_max............: 64      min=64         max=64
-     ws_connecting......: avg=15.87ms min=1.7ms med=2.79ms max=65.28ms p(90)=62.97ms p(95)=63.61ms
-     ws_msgs_received...: 2478834 70818.793428/s
-     ws_msgs_sent.......: 2478896 70820.564731/s
-     ws_sessions........: 64      1.828441/s
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 64      min=64         max=64
+    vus_max............................: 64      min=64         max=64
+
+    NETWORK
+    data_received......................: 26 MB   739 kB/s
+    data_sent..........................: 32 MB   907 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=11.74ms min=4.1ms med=12.64ms max=22.63ms p(90)=17.61ms p(95)=19.72ms
+    ws_msgs_received...................: 1475014 42142.608147/s
+    ws_msgs_sent.......................: 1475078 42144.43669/s
+    ws_sessions........................: 64      1.828543/s
+
+
 
 
 running (35.0s), 00/64 VUs, 0 complete and 64 interrupted iterations

--- a/results/vus-64/fasthttp-websocket/plain-sync.txt
+++ b/results/vus-64/fasthttp-websocket/plain-sync.txt
@@ -1,16 +1,16 @@
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ./benchmarks/plain-sync.js
-     output: -
+     execution: local
+        script: ./benchmarks/plain-sync.js
+        output: -
 
-  scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
-           * default: 64 looping VUs for 5s (gracefulStop: 30s)
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
 
 
 running (01.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
@@ -117,17 +117,26 @@ default ↓ [ 100% ] 64 VUs  5s
 
 running (35.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
+time="2025-09-30T19:01:40+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
 
-     ✓ status is 101
 
-     data_received......: 36 MB   1.0 MB/s
-     data_sent..........: 46 MB   1.3 MB/s
-     vus................: 64      min=64         max=64
-     vus_max............: 64      min=64         max=64
-     ws_connecting......: avg=17.11ms min=2.33ms med=3.42ms max=67.01ms p(90)=66.55ms p(95)=66.69ms
-     ws_msgs_received...: 2447565 69930.624711/s
-     ws_msgs_sent.......: 2447627 69932.396144/s
-     ws_sessions........: 64      1.828577/s
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 64      min=64         max=64
+    vus_max............................: 64      min=64         max=64
+
+    NETWORK
+    data_received......................: 23 MB   661 kB/s
+    data_sent..........................: 30 MB   843 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=19.92ms min=6.23ms med=23.26ms max=29.76ms p(90)=28.07ms p(95)=29.42ms
+    ws_msgs_received...................: 1589782 45420.170475/s
+    ws_msgs_sent.......................: 1589846 45421.998959/s
+    ws_sessions........................: 64      1.828484/s
+
+
 
 
 running (35.0s), 00/64 VUs, 0 complete and 64 interrupted iterations

--- a/results/vus-64/gorilla-websocket/binary-async.txt
+++ b/results/vus-64/gorilla-websocket/binary-async.txt
@@ -1,32 +1,32 @@
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ./benchmarks/binary-async.js
-     output: -
+     execution: local
+        script: ./benchmarks/binary-async.js
+        output: -
 
-  scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
-           * default: 64 looping VUs for 5s (gracefulStop: 30s)
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
 
 
 running (01.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  19% ] 64 VUs  1.0s/5s
+default   [  20% ] 64 VUs  1.0s/5s
 
 running (02.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  39% ] 64 VUs  2.0s/5s
+default   [  40% ] 64 VUs  2.0s/5s
 
 running (03.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  59% ] 64 VUs  3.0s/5s
+default   [  60% ] 64 VUs  3.0s/5s
 
 running (04.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  79% ] 64 VUs  4.0s/5s
+default   [  80% ] 64 VUs  4.0s/5s
 
 running (05.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  99% ] 64 VUs  5.0s/5s
+default   [ 100% ] 64 VUs  5.0s/5s
 
 running (06.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
@@ -52,26 +52,92 @@ default ↓ [ 100% ] 64 VUs  5s
 running (13.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (14.0s), 62/64 VUs, 2 complete and 0 interrupted iterations
+running (14.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-     ✓ expected ${this} to be a number
-     ✓ expected ${this} to equal +0
-     ✓ status is 101
+running (15.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
 
-     checks................: 100.00% ✓ 192           ✗ 0   
-     data_received.........: 38 MB   2.6 MB/s
-     data_sent.............: 64 MB   4.3 MB/s
-     iteration_duration....: avg=14.54s  min=13.94s med=14.62s  max=14.73s   p(90)=14.7s    p(95)=14.72s  
-     iterations............: 64      4.344069/s
-     vus...................: 62      min=62          max=64
-     vus_max...............: 64      min=64          max=64
-     ws_connecting.........: avg=57.55ms min=1.88ms med=31.18ms max=223.02ms p(90)=187.19ms p(95)=221.53ms
-     ws_msgs_received......: 6400000 434406.944224/s
-     ws_msgs_sent..........: 6400000 434406.944224/s
-     ws_session_duration...: avg=14.54s  min=13.94s med=14.62s  max=14.73s   p(90)=14.7s    p(95)=14.72s  
-     ws_sessions...........: 64      4.344069/s
+running (16.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (17.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (18.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (19.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (20.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (21.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (22.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (23.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (24.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (25.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (26.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (27.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (28.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (29.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (30.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (31.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (32.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (33.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (34.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (35.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+time="2025-09-30T19:08:02+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
 
 
-running (14.7s), 00/64 VUs, 64 complete and 0 interrupted iterations
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 64      min=64          max=64
+    vus_max............................: 64      min=64          max=64
+
+    NETWORK
+    data_received......................: 242 kB  6.9 kB/s
+    data_sent..........................: 58 MB   1.7 MB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=39.74ms min=5.87ms med=46.15ms max=57.99ms p(90)=46.56ms p(95)=46.74ms
+    ws_msgs_received...................: 36901   1050.834881/s
+    ws_msgs_sent.......................: 5823009 165822.632764/s
+    ws_sessions........................: 64      1.822537/s
+
+
+
+
+running (35.1s), 00/64 VUs, 0 complete and 64 interrupted iterations
 default ✓ [ 100% ] 64 VUs  5s

--- a/results/vus-64/gorilla-websocket/binary-sync.txt
+++ b/results/vus-64/gorilla-websocket/binary-sync.txt
@@ -1,16 +1,16 @@
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ./benchmarks/binary-sync.js
-     output: -
+     execution: local
+        script: ./benchmarks/binary-sync.js
+        output: -
 
-  scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
-           * default: 64 looping VUs for 5s (gracefulStop: 30s)
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
 
 
 running (01.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
@@ -117,17 +117,26 @@ default ↓ [ 100% ] 64 VUs  5s
 
 running (35.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
+time="2025-09-30T19:07:21+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
 
-     ✓ status is 101
 
-     data_received......: 14 MB   406 kB/s
-     data_sent..........: 24 MB   676 kB/s
-     vus................: 64      min=64         max=64
-     vus_max............: 64      min=64         max=64
-     ws_connecting......: avg=65.75ms min=2.34ms med=70.8ms max=81.06ms p(90)=76.74ms p(95)=78.46ms
-     ws_msgs_received...: 2365392 67583.49342/s
-     ws_msgs_sent.......: 2365450 67585.150584/s
-     ws_sessions........: 64      1.828595/s
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 64     min=64         max=64
+    vus_max............................: 64     min=64         max=64
+
+    NETWORK
+    data_received......................: 4.8 MB 136 kB/s
+    data_sent..........................: 7.9 MB 226 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=13.08ms min=4.89ms med=13.23ms max=19.34ms p(90)=17.59ms p(95)=18.68ms
+    ws_msgs_received...................: 790443 22580.735378/s
+    ws_msgs_sent.......................: 790507 22582.563678/s
+    ws_sessions........................: 64     1.8283/s
+
+
 
 
 running (35.0s), 00/64 VUs, 0 complete and 64 interrupted iterations

--- a/results/vus-64/gorilla-websocket/connection.txt
+++ b/results/vus-64/gorilla-websocket/connection.txt
@@ -1,46 +1,60 @@
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ./benchmarks/connection.js
-     output: -
+     execution: local
+        script: ./benchmarks/connection.js
+        output: -
 
-  scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
-           * default: 64 looping VUs for 5s (gracefulStop: 30s)
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
 
 
-running (01.0s), 64/64 VUs, 10550 complete and 0 interrupted iterations
+running (01.0s), 64/64 VUs, 7935 complete and 0 interrupted iterations
 default   [  20% ] 64 VUs  1.0s/5s
 
-running (02.0s), 64/64 VUs, 21912 complete and 0 interrupted iterations
+running (02.0s), 64/64 VUs, 15537 complete and 0 interrupted iterations
 default   [  40% ] 64 VUs  2.0s/5s
 
-running (03.0s), 64/64 VUs, 31664 complete and 0 interrupted iterations
+running (03.0s), 64/64 VUs, 16963 complete and 0 interrupted iterations
 default   [  60% ] 64 VUs  3.0s/5s
 
-running (04.0s), 64/64 VUs, 42229 complete and 0 interrupted iterations
+running (04.0s), 64/64 VUs, 17785 complete and 0 interrupted iterations
 default   [  80% ] 64 VUs  4.0s/5s
 
-running (05.0s), 64/64 VUs, 53709 complete and 0 interrupted iterations
-default   [ 100% ] 64 VUs  5.0s/5s
-
-     ✓ status is 101
-
-     checks................: 100.00% ✓ 53804        ✗ 0   
-     data_received.........: 6.9 MB  1.4 MB/s
-     data_sent.............: 11 MB   2.3 MB/s
-     iteration_duration....: avg=5.93ms min=721.38µs med=5.38ms max=75.64ms p(90)=9ms    p(95)=10.62ms
-     iterations............: 53804   10754.352134/s
-     vus...................: 64      min=64         max=64
-     vus_max...............: 64      min=64         max=64
-     ws_connecting.........: avg=5.83ms min=621.41µs med=5.28ms max=75.57ms p(90)=8.87ms p(95)=10.48ms
-     ws_session_duration...: avg=5.89ms min=690.62µs med=5.33ms max=75.59ms p(90)=8.94ms p(95)=10.57ms
-     ws_sessions...........: 53804   10754.352134/s
+running (05.0s), 58/64 VUs, 18603 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
 
 
-running (05.0s), 00/64 VUs, 53804 complete and 0 interrupted iterations
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 18661  3684.084384/s
+    checks_succeeded...................: 87.69% 16365 out of 18661
+    checks_failed......................: 12.30% 2296 out of 18661
+
+    ✗ status is 101
+      ↳  87% — ✓ 16365 / ✗ 2296
+
+    EXECUTION
+    iteration_duration.......................: avg=17.27ms min=586.12µs med=8.3ms  max=2.35s p(90)=44.72ms p(95)=69ms   
+    iterations...............................: 18661  3684.084384/s
+    vus......................................: 64     min=64        max=64
+    vus_max..................................: 64     min=64        max=64
+
+    NETWORK
+    data_received............................: 2.1 MB 417 kB/s
+    data_sent................................: 3.3 MB 649 kB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=17.21ms min=556.54µs med=8.26ms max=2.35s p(90)=44.63ms p(95)=68.91ms
+    ws_session_duration......................: avg=17.24ms min=575.37µs med=8.29ms max=2.35s p(90)=44.69ms p(95)=68.92ms
+    ws_sessions..............................: 18661  3684.084384/s
+
+
+
+
+running (05.1s), 00/64 VUs, 18661 complete and 0 interrupted iterations
 default ✓ [ 100% ] 64 VUs  5s

--- a/results/vus-64/gorilla-websocket/json-async.txt
+++ b/results/vus-64/gorilla-websocket/json-async.txt
@@ -1,32 +1,32 @@
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ./benchmarks/json-async.js
-     output: -
+     execution: local
+        script: ./benchmarks/json-async.js
+        output: -
 
-  scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
-           * default: 64 looping VUs for 5s (gracefulStop: 30s)
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
 
 
 running (01.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default   [  20% ] 64 VUs  1.0s/5s
 
 running (02.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  39% ] 64 VUs  2.0s/5s
+default   [  40% ] 64 VUs  2.0s/5s
 
 running (03.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  59% ] 64 VUs  3.0s/5s
+default   [  60% ] 64 VUs  3.0s/5s
 
 running (04.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  79% ] 64 VUs  4.0s/5s
+default   [  81% ] 64 VUs  4.0s/5s
 
 running (05.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  99% ] 64 VUs  5.0s/5s
+default   [ 100% ] 64 VUs  5.0s/5s
 
 running (06.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
@@ -46,26 +46,98 @@ default ↓ [ 100% ] 64 VUs  5s
 running (11.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (12.0s), 63/64 VUs, 1 complete and 0 interrupted iterations
+running (12.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-     ✓ expected ${this} to be a number
-     ✓ expected ${this} to equal +0
-     ✓ status is 101
+running (13.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
 
-     checks................: 100.00% ✓ 192           ✗ 0   
-     data_received.........: 115 MB  8.9 MB/s
-     data_sent.............: 140 MB  11 MB/s
-     iteration_duration....: avg=12.65s  min=11.88s med=12.71s  max=12.83s  p(90)=12.82s  p(95)=12.82s 
-     iterations............: 64      4.98668/s
-     vus...................: 63      min=63          max=64
-     vus_max...............: 64      min=64          max=64
-     ws_connecting.........: avg=78.25ms min=3.5ms  med=79.28ms max=94.73ms p(90)=91.34ms p(95)=92.96ms
-     ws_msgs_received......: 6400000 498667.980764/s
-     ws_msgs_sent..........: 6400000 498667.980764/s
-     ws_session_duration...: avg=12.65s  min=11.88s med=12.71s  max=12.83s  p(90)=12.82s  p(95)=12.82s 
-     ws_sessions...........: 64      4.98668/s
+running (14.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (15.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (16.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (17.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (18.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (19.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (20.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (21.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (22.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (23.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (24.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (25.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (26.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (27.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (28.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (29.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (30.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (31.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (32.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (33.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (34.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (35.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+time="2025-09-30T19:06:39+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
 
 
-running (12.8s), 00/64 VUs, 64 complete and 0 interrupted iterations
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 64      min=64          max=64
+    vus_max............................: 64      min=64          max=64
+
+    NETWORK
+    data_received......................: 23 MB   669 kB/s
+    data_sent..........................: 140 MB  4.0 MB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=37.34ms min=5.33ms med=40.8ms max=41.42ms p(90)=41.15ms p(95)=41.18ms
+    ws_msgs_received...................: 1331799 38048.668106/s
+    ws_msgs_sent.......................: 6400000 182844.014657/s
+    ws_sessions........................: 64      1.82844/s
+
+
+
+
+running (35.0s), 00/64 VUs, 0 complete and 64 interrupted iterations
 default ✓ [ 100% ] 64 VUs  5s

--- a/results/vus-64/gorilla-websocket/json-sync.txt
+++ b/results/vus-64/gorilla-websocket/json-sync.txt
@@ -1,16 +1,16 @@
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ./benchmarks/json-sync.js
-     output: -
+     execution: local
+        script: ./benchmarks/json-sync.js
+        output: -
 
-  scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
-           * default: 64 looping VUs for 5s (gracefulStop: 30s)
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
 
 
 running (01.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
@@ -117,17 +117,26 @@ default ↓ [ 100% ] 64 VUs  5s
 
 running (35.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
+time="2025-09-30T19:05:58+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
 
-     ✓ status is 101
 
-     data_received......: 42 MB   1.2 MB/s
-     data_sent..........: 51 MB   1.5 MB/s
-     vus................: 64      min=64         max=64
-     vus_max............: 64      min=64         max=64
-     ws_connecting......: avg=18.61ms min=3.79ms med=5.47ms max=67.78ms p(90)=67.66ms p(95)=67.75ms
-     ws_msgs_received...: 2370246 67720.472743/s
-     ws_msgs_sent.......: 2370310 67722.301291/s
-     ws_sessions........: 64      1.828549/s
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 64     min=64         max=64
+    vus_max............................: 64     min=64         max=64
+
+    NETWORK
+    data_received......................: 15 MB  419 kB/s
+    data_sent..........................: 18 MB  517 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=18.84ms min=5.92ms med=23.6ms max=28.18ms p(90)=27.04ms p(95)=28.02ms
+    ws_msgs_received...................: 854232 24405.973097/s
+    ws_msgs_sent.......................: 854295 24407.773048/s
+    ws_sessions........................: 64     1.828522/s
+
+
 
 
 running (35.0s), 00/64 VUs, 0 complete and 64 interrupted iterations

--- a/results/vus-64/gorilla-websocket/plain-sync.txt
+++ b/results/vus-64/gorilla-websocket/plain-sync.txt
@@ -1,134 +1,152 @@
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ./benchmarks/plain-sync.js
-     output: -
+     execution: local
+        script: ./benchmarks/plain-sync.js
+        output: -
 
-  scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
-           * default: 64 looping VUs for 5s (gracefulStop: 30s)
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
 
 
-running (01.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (01.0s), 64/64 VUs, 1201 complete and 0 interrupted iterations
 default   [  20% ] 64 VUs  1.0s/5s
 
-running (02.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (02.0s), 64/64 VUs, 2288 complete and 0 interrupted iterations
 default   [  40% ] 64 VUs  2.0s/5s
 
-running (03.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (03.0s), 64/64 VUs, 3476 complete and 0 interrupted iterations
 default   [  60% ] 64 VUs  3.0s/5s
 
-running (04.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (04.0s), 64/64 VUs, 4716 complete and 0 interrupted iterations
 default   [  80% ] 64 VUs  4.0s/5s
 
-running (05.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (05.0s), 64/64 VUs, 5960 complete and 0 interrupted iterations
 default   [ 100% ] 64 VUs  5.0s/5s
 
-running (06.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (06.0s), 03/64 VUs, 6026 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (07.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (07.0s), 03/64 VUs, 6026 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (08.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (08.0s), 03/64 VUs, 6026 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (09.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (09.0s), 03/64 VUs, 6026 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (10.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (10.0s), 03/64 VUs, 6026 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (11.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (11.0s), 03/64 VUs, 6026 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (12.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (12.0s), 03/64 VUs, 6026 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (13.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (13.0s), 03/64 VUs, 6026 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (14.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (14.0s), 03/64 VUs, 6026 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (15.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (15.0s), 03/64 VUs, 6026 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (16.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (16.0s), 03/64 VUs, 6026 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (17.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (17.0s), 03/64 VUs, 6026 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (18.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (18.0s), 03/64 VUs, 6026 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (19.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (19.0s), 03/64 VUs, 6026 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (20.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (20.0s), 03/64 VUs, 6026 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (21.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (21.0s), 03/64 VUs, 6026 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (22.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (22.0s), 03/64 VUs, 6026 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (23.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (23.0s), 03/64 VUs, 6026 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (24.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (24.0s), 03/64 VUs, 6026 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (25.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (25.0s), 03/64 VUs, 6026 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (26.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (26.0s), 03/64 VUs, 6026 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (27.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (27.0s), 03/64 VUs, 6026 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (28.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (28.0s), 03/64 VUs, 6026 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (29.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (29.0s), 03/64 VUs, 6026 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (30.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (30.0s), 03/64 VUs, 6026 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (31.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (31.0s), 03/64 VUs, 6026 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (32.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (32.0s), 03/64 VUs, 6026 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (33.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (33.0s), 03/64 VUs, 6026 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (34.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (34.0s), 03/64 VUs, 6026 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (35.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (35.0s), 03/64 VUs, 6026 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-     ✓ status is 101
 
-     data_received......: 37 MB   1.1 MB/s
-     data_sent..........: 47 MB   1.3 MB/s
-     vus................: 64      min=64         max=64
-     vus_max............: 64      min=64         max=64
-     ws_connecting......: avg=23.38ms min=2.57ms med=5.38ms max=91.52ms p(90)=89.8ms p(95)=90.18ms
-     ws_msgs_received...: 2518862 71961.0917/s
-     ws_msgs_sent.......: 2518926 71962.920109/s
-     ws_sessions........: 64      1.828409/s
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 6026    172.17103/s
+    checks_succeeded...................: 0.00%   0 out of 6026
+    checks_failed......................: 100.00% 6026 out of 6026
+
+    ✗ status is 101
+      ↳  0% — ✓ 0 / ✗ 6026
+
+    EXECUTION
+    iteration_duration.......................: avg=52.06ms min=2.83ms med=51.09ms max=137.29ms p(90)=70.94ms p(95)=79.11ms
+    iterations...............................: 6026   172.17103/s
+    vus......................................: 3      min=3          max=64
+    vus_max..................................: 64     min=64         max=64
+
+    NETWORK
+    data_received............................: 7.6 MB 218 kB/s
+    data_sent................................: 9.6 MB 275 kB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=52.07ms min=2.81ms med=51ms    max=485.26ms p(90)=70.88ms p(95)=79.01ms
+    ws_msgs_received.........................: 497067 14201.881419/s
+    ws_msgs_sent.............................: 497070 14201.967133/s
+    ws_session_duration......................: avg=51.98ms min=2.82ms med=51.02ms max=137.27ms p(90)=70.89ms p(95)=78.97ms
+    ws_sessions..............................: 6029   172.256744/s
 
 
-running (35.0s), 00/64 VUs, 0 complete and 64 interrupted iterations
+
+
+running (35.0s), 00/64 VUs, 6026 complete and 3 interrupted iterations
 default ✓ [ 100% ] 64 VUs  5s

--- a/results/vus-64/tokio-tungstenite/binary-async.txt
+++ b/results/vus-64/tokio-tungstenite/binary-async.txt
@@ -1,29 +1,29 @@
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ./benchmarks/binary-async.js
-     output: -
+     execution: local
+        script: ./benchmarks/binary-async.js
+        output: -
 
-  scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
-           * default: 64 looping VUs for 5s (gracefulStop: 30s)
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
 
 
 running (01.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  19% ] 64 VUs  1.0s/5s
+default   [  20% ] 64 VUs  1.0s/5s
 
 running (02.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  39% ] 64 VUs  2.0s/5s
+default   [  40% ] 64 VUs  2.0s/5s
 
 running (03.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  59% ] 64 VUs  3.0s/5s
+default   [  60% ] 64 VUs  3.0s/5s
 
 running (04.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  79% ] 64 VUs  4.0s/5s
+default   [  80% ] 64 VUs  4.0s/5s
 
 running (05.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default   [  99% ] 64 VUs  5.0s/5s
@@ -46,26 +46,75 @@ default ↓ [ 100% ] 64 VUs  5s
 running (11.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (12.0s), 63/64 VUs, 1 complete and 0 interrupted iterations
+running (12.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-     ✓ expected ${this} to be a number
-     ✓ expected ${this} to equal +0
-     ✓ status is 101
+running (13.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
 
-     checks................: 100.00% ✓ 192          ✗ 0   
-     data_received.........: 38 MB   3.0 MB/s
-     data_sent.............: 64 MB   4.9 MB/s
-     iteration_duration....: avg=12.79s  min=11.94s med=12.88s  max=12.94s p(90)=12.93s p(95)=12.93s 
-     iterations............: 64      4.945481/s
-     vus...................: 63      min=63         max=64
-     vus_max...............: 64      min=64         max=64
-     ws_connecting.........: avg=41.33ms min=2.38ms med=45.33ms max=53.2ms p(90)=52.8ms p(95)=52.88ms
-     ws_msgs_received......: 6400000 494548.05839/s
-     ws_msgs_sent..........: 6400000 494548.05839/s
-     ws_session_duration...: avg=12.79s  min=11.94s med=12.88s  max=12.94s p(90)=12.93s p(95)=12.93s 
-     ws_sessions...........: 64      4.945481/s
+running (14.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (15.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (16.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (17.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (18.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (19.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (20.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (21.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (22.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (23.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (24.0s), 62/64 VUs, 2 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
 
 
-running (12.9s), 00/64 VUs, 64 complete and 0 interrupted iterations
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 192     7.729853/s
+    checks_succeeded...................: 100.00% 192 out of 192
+    checks_failed......................: 0.00%   0 out of 192
+
+    ✓ expected ${this} to be a number
+    ✓ expected ${this} to equal +0
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=24.6s   min=23.91s med=24.69s  max=24.83s  p(90)=24.82s  p(95)=24.83s 
+    iterations...............................: 64      2.576618/s
+    vus......................................: 62      min=62          max=64
+    vus_max..................................: 64      min=64          max=64
+
+    NETWORK
+    data_received............................: 38 MB   1.5 MB/s
+    data_sent................................: 64 MB   2.6 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=29.04ms min=4.42ms med=32.88ms max=39.12ms p(90)=38.88ms p(95)=39.01ms
+    ws_msgs_received.........................: 6400000 257661.753406/s
+    ws_msgs_sent.............................: 6400000 257661.753406/s
+    ws_session_duration......................: avg=24.6s   min=23.91s med=24.69s  max=24.83s  p(90)=24.82s  p(95)=24.83s 
+    ws_sessions..............................: 64      2.576618/s
+
+
+
+
+running (24.8s), 00/64 VUs, 64 complete and 0 interrupted iterations
 default ✓ [ 100% ] 64 VUs  5s

--- a/results/vus-64/tokio-tungstenite/binary-sync.txt
+++ b/results/vus-64/tokio-tungstenite/binary-sync.txt
@@ -1,16 +1,16 @@
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ./benchmarks/binary-sync.js
-     output: -
+     execution: local
+        script: ./benchmarks/binary-sync.js
+        output: -
 
-  scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
-           * default: 64 looping VUs for 5s (gracefulStop: 30s)
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
 
 
 running (01.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
@@ -117,17 +117,26 @@ default ↓ [ 100% ] 64 VUs  5s
 
 running (35.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
+time="2025-09-30T18:59:32+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
 
-     ✓ status is 101
 
-     data_received......: 17 MB   483 kB/s
-     data_sent..........: 28 MB   805 kB/s
-     vus................: 64      min=64         max=64
-     vus_max............: 64      min=64         max=64
-     ws_connecting......: avg=21.4ms min=3.67ms med=5.98ms max=90.77ms p(90)=89.8ms p(95)=90.03ms
-     ws_msgs_received...: 2817474 80498.928468/s
-     ws_msgs_sent.......: 2817537 80500.728461/s
-     ws_sessions........: 64      1.828564/s
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 64      min=64         max=64
+    vus_max............................: 64      min=64         max=64
+
+    NETWORK
+    data_received......................: 9.5 MB  271 kB/s
+    data_sent..........................: 16 MB   452 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=15.23ms min=5.24ms med=14.95ms max=36.26ms p(90)=26.09ms p(95)=33.85ms
+    ws_msgs_received...................: 1579888 45137.555022/s
+    ws_msgs_sent.......................: 1579952 45139.383509/s
+    ws_sessions........................: 64      1.828486/s
+
+
 
 
 running (35.0s), 00/64 VUs, 0 complete and 64 interrupted iterations

--- a/results/vus-64/tokio-tungstenite/connection.txt
+++ b/results/vus-64/tokio-tungstenite/connection.txt
@@ -1,46 +1,59 @@
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ./benchmarks/connection.js
-     output: -
+     execution: local
+        script: ./benchmarks/connection.js
+        output: -
 
-  scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
-           * default: 64 looping VUs for 5s (gracefulStop: 30s)
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
 
 
-running (01.0s), 64/64 VUs, 12733 complete and 0 interrupted iterations
+running (01.0s), 64/64 VUs, 8783 complete and 0 interrupted iterations
 default   [  20% ] 64 VUs  1.0s/5s
 
-running (02.0s), 64/64 VUs, 25582 complete and 0 interrupted iterations
+running (02.0s), 64/64 VUs, 17563 complete and 0 interrupted iterations
 default   [  40% ] 64 VUs  2.0s/5s
 
-running (03.0s), 64/64 VUs, 39648 complete and 0 interrupted iterations
+running (03.0s), 64/64 VUs, 25887 complete and 0 interrupted iterations
 default   [  60% ] 64 VUs  3.0s/5s
 
-running (04.0s), 64/64 VUs, 52734 complete and 0 interrupted iterations
+running (04.0s), 64/64 VUs, 34653 complete and 0 interrupted iterations
 default   [  80% ] 64 VUs  4.0s/5s
 
-running (05.0s), 64/64 VUs, 65645 complete and 0 interrupted iterations
+running (05.0s), 64/64 VUs, 42631 complete and 0 interrupted iterations
 default   [ 100% ] 64 VUs  5.0s/5s
 
-     ✓ status is 101
 
-     checks................: 100.00% ✓ 65725        ✗ 0   
-     data_received.........: 8.5 MB  1.7 MB/s
-     data_sent.............: 14 MB   2.8 MB/s
-     iteration_duration....: avg=4.86ms min=631.25µs med=4.52ms max=80.92ms p(90)=6.88ms p(95)=7.84ms
-     iterations............: 65725   13137.162324/s
-     vus...................: 64      min=64         max=64
-     vus_max...............: 64      min=64         max=64
-     ws_connecting.........: avg=4.77ms min=551.53µs med=4.44ms max=80.03ms p(90)=6.78ms p(95)=7.72ms
-     ws_session_duration...: avg=4.82ms min=607.21µs med=4.49ms max=80.26ms p(90)=6.84ms p(95)=7.79ms
-     ws_sessions...........: 65725   13137.162324/s
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 42741   8539.409532/s
+    checks_succeeded...................: 100.00% 42741 out of 42741
+    checks_failed......................: 0.00%   0 out of 42741
+
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=7.48ms min=981.7µs  med=7ms    max=43.69ms p(90)=10.08ms p(95)=11.86ms
+    iterations...............................: 42741  8539.409532/s
+    vus......................................: 64     min=64        max=64
+    vus_max..................................: 64     min=64        max=64
+
+    NETWORK
+    data_received............................: 5.5 MB 1.1 MB/s
+    data_sent................................: 8.6 MB 1.7 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=7.45ms min=950.75µs med=6.97ms max=43.67ms p(90)=10.05ms p(95)=11.82ms
+    ws_session_duration......................: avg=7.47ms min=972.83µs med=6.99ms max=43.68ms p(90)=10.07ms p(95)=11.84ms
+    ws_sessions..............................: 42741  8539.409532/s
 
 
-running (05.0s), 00/64 VUs, 65725 complete and 0 interrupted iterations
+
+
+running (05.0s), 00/64 VUs, 42741 complete and 0 interrupted iterations
 default ✓ [ 100% ] 64 VUs  5s

--- a/results/vus-64/tokio-tungstenite/json-async.txt
+++ b/results/vus-64/tokio-tungstenite/json-async.txt
@@ -1,29 +1,29 @@
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ./benchmarks/json-async.js
-     output: -
+     execution: local
+        script: ./benchmarks/json-async.js
+        output: -
 
-  scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
-           * default: 64 looping VUs for 5s (gracefulStop: 30s)
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
 
 
 running (01.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  19% ] 64 VUs  1.0s/5s
+default   [  20% ] 64 VUs  1.0s/5s
 
 running (02.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  39% ] 64 VUs  2.0s/5s
+default   [  40% ] 64 VUs  2.0s/5s
 
 running (03.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  59% ] 64 VUs  3.0s/5s
+default   [  60% ] 64 VUs  3.0s/5s
 
 running (04.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  79% ] 64 VUs  4.0s/5s
+default   [  80% ] 64 VUs  4.0s/5s
 
 running (05.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default   [  99% ] 64 VUs  5.0s/5s
@@ -43,35 +43,72 @@ default ↓ [ 100% ] 64 VUs  5s
 running (10.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (11.0s), 63/64 VUs, 1 complete and 0 interrupted iterations
+running (11.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (12.0s), 51/64 VUs, 13 complete and 0 interrupted iterations
+running (12.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (13.0s), 25/64 VUs, 39 complete and 0 interrupted iterations
+running (13.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (14.0s), 21/64 VUs, 43 complete and 0 interrupted iterations
+running (14.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-     ✓ expected ${this} to be a number
-     ✓ expected ${this} to equal +0
-     ✓ status is 101
+running (15.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
 
-     checks................: 100.00% ✓ 192           ✗ 0   
-     data_received.........: 115 MB  7.9 MB/s
-     data_sent.............: 140 MB  9.7 MB/s
-     iteration_duration....: avg=12.99s  min=10.79s med=12.6s   max=14.45s  p(90)=14.36s  p(95)=14.43s
-     iterations............: 64      4.42562/s
-     vus...................: 21      min=21          max=64
-     vus_max...............: 64      min=64          max=64
-     ws_connecting.........: avg=29.69ms min=1.2ms  med=21.72ms max=94.37ms p(90)=88.01ms p(95)=89.6ms
-     ws_msgs_received......: 6400000 442561.993299/s
-     ws_msgs_sent..........: 6400000 442561.993299/s
-     ws_session_duration...: avg=12.99s  min=10.79s med=12.6s   max=14.45s  p(90)=14.36s  p(95)=14.43s
-     ws_sessions...........: 64      4.42562/s
+running (16.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (17.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (18.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (19.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (20.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (21.0s), 62/64 VUs, 2 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (22.0s), 49/64 VUs, 15 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
 
 
-running (14.5s), 00/64 VUs, 64 complete and 0 interrupted iterations
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 192     8.596432/s
+    checks_succeeded...................: 100.00% 192 out of 192
+    checks_failed......................: 0.00%   0 out of 192
+
+    ✓ expected ${this} to be a number
+    ✓ expected ${this} to equal +0
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=22.06s  min=20.58s med=22.19s  max=22.33s p(90)=22.32s  p(95)=22.32s 
+    iterations...............................: 64      2.865477/s
+    vus......................................: 49      min=49          max=64
+    vus_max..................................: 64      min=64          max=64
+
+    NETWORK
+    data_received............................: 115 MB  5.1 MB/s
+    data_sent................................: 140 MB  6.3 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=36.91ms min=4.88ms med=40.28ms max=53.6ms p(90)=52.87ms p(95)=53.01ms
+    ws_msgs_received.........................: 6400000 286547.730255/s
+    ws_msgs_sent.............................: 6400000 286547.730255/s
+    ws_session_duration......................: avg=22.06s  min=20.58s med=22.19s  max=22.33s p(90)=22.31s  p(95)=22.32s 
+    ws_sessions..............................: 64      2.865477/s
+
+
+
+
+running (22.3s), 00/64 VUs, 64 complete and 0 interrupted iterations
 default ✓ [ 100% ] 64 VUs  5s

--- a/results/vus-64/tokio-tungstenite/json-sync.txt
+++ b/results/vus-64/tokio-tungstenite/json-sync.txt
@@ -1,16 +1,16 @@
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ./benchmarks/json-sync.js
-     output: -
+     execution: local
+        script: ./benchmarks/json-sync.js
+        output: -
 
-  scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
-           * default: 64 looping VUs for 5s (gracefulStop: 30s)
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
 
 
 running (01.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
@@ -117,17 +117,26 @@ default ↓ [ 100% ] 64 VUs  5s
 
 running (35.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
+time="2025-09-30T18:58:02+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
 
-     ✓ status is 101
 
-     data_received......: 51 MB   1.5 MB/s
-     data_sent..........: 62 MB   1.8 MB/s
-     vus................: 64      min=64         max=64
-     vus_max............: 64      min=64         max=64
-     ws_connecting......: avg=14.39ms min=2.29ms med=4.74ms max=59.05ms p(90)=58.77ms p(95)=58.94ms
-     ws_msgs_received...: 2860380 81725.569759/s
-     ws_msgs_sent.......: 2860443 81727.369768/s
-     ws_sessions........: 64      1.828581/s
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 64      min=64         max=64
+    vus_max............................: 64      min=64         max=64
+
+    NETWORK
+    data_received......................: 29 MB   827 kB/s
+    data_sent..........................: 36 MB   1.0 MB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=16.03ms min=4.91ms med=16.87ms max=26.71ms p(90)=25.99ms p(95)=26.2ms
+    ws_msgs_received...................: 1646823 47050.605637/s
+    ws_msgs_sent.......................: 1646887 47052.434151/s
+    ws_sessions........................: 64      1.828514/s
+
+
 
 
 running (35.0s), 00/64 VUs, 0 complete and 64 interrupted iterations

--- a/results/vus-64/tokio-tungstenite/plain-sync.txt
+++ b/results/vus-64/tokio-tungstenite/plain-sync.txt
@@ -1,16 +1,16 @@
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ./benchmarks/plain-sync.js
-     output: -
+     execution: local
+        script: ./benchmarks/plain-sync.js
+        output: -
 
-  scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
-           * default: 64 looping VUs for 5s (gracefulStop: 30s)
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
 
 
 running (01.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
@@ -117,17 +117,26 @@ default ↓ [ 100% ] 64 VUs  5s
 
 running (35.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
+time="2025-10-06T12:21:42+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
 
-     ✓ status is 101
 
-     data_received......: 44 MB   1.3 MB/s
-     data_sent..........: 56 MB   1.6 MB/s
-     vus................: 64      min=64         max=64
-     vus_max............: 64      min=64         max=64
-     ws_connecting......: avg=19.14ms min=3.28ms med=4.7ms max=83.05ms p(90)=82.93ms p(95)=82.96ms
-     ws_msgs_received...: 2986187 85319.834997/s
-     ws_msgs_sent.......: 2986248 85321.577858/s
-     ws_sessions........: 64      1.828576/s
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 64      min=64         max=64
+    vus_max............................: 64      min=64         max=64
+
+    NETWORK
+    data_received......................: 25 MB   726 kB/s
+    data_sent..........................: 32 MB   925 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=19.01ms min=8.09ms med=17.24ms max=37.44ms p(90)=36.73ms p(95)=37.13ms
+    ws_msgs_received...................: 1740071 49713.264732/s
+    ws_msgs_sent.......................: 1740135 49715.093191/s
+    ws_sessions........................: 64      1.828459/s
+
+
 
 
 running (35.0s), 00/64 VUs, 0 complete and 64 interrupted iterations

--- a/results/vus-64/uwebsocket-js/binary-async.txt
+++ b/results/vus-64/uwebsocket-js/binary-async.txt
@@ -1,32 +1,32 @@
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ./benchmarks/binary-async.js
-     output: -
+     execution: local
+        script: ./benchmarks/binary-async.js
+        output: -
 
-  scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
-           * default: 64 looping VUs for 5s (gracefulStop: 30s)
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
 
 
 running (01.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  20% ] 64 VUs  1.0s/5s
+default   [  19% ] 64 VUs  1.0s/5s
 
 running (02.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  39% ] 64 VUs  2.0s/5s
+default   [  40% ] 64 VUs  2.0s/5s
 
 running (03.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  59% ] 64 VUs  3.0s/5s
+default   [  61% ] 64 VUs  3.0s/5s
 
 running (04.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  79% ] 64 VUs  4.0s/5s
+default   [  80% ] 64 VUs  4.0s/5s
 
 running (05.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  99% ] 64 VUs  5.0s/5s
+default   [ 100% ] 64 VUs  5.0s/5s
 
 running (06.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
@@ -52,26 +52,92 @@ default ↓ [ 100% ] 64 VUs  5s
 running (13.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (14.0s), 48/64 VUs, 16 complete and 0 interrupted iterations
+running (14.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-     ✓ expected ${this} to be a number
-     ✓ expected ${this} to equal +0
-     ✓ status is 101
+running (15.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
 
-     checks................: 100.00% ✓ 192           ✗ 0   
-     data_received.........: 38 MB   2.7 MB/s
-     data_sent.............: 64 MB   4.5 MB/s
-     iteration_duration....: avg=14.02s  min=13.36s med=14.08s  max=14.18s  p(90)=14.17s  p(95)=14.18s 
-     iterations............: 64      4.510465/s
-     vus...................: 48      min=48          max=64
-     vus_max...............: 64      min=64          max=64
-     ws_connecting.........: avg=57.82ms min=3.01ms med=56.52ms max=72.25ms p(90)=71.14ms p(95)=71.29ms
-     ws_msgs_received......: 6400000 451046.522207/s
-     ws_msgs_sent..........: 6400000 451046.522207/s
-     ws_session_duration...: avg=14.02s  min=13.36s med=14.08s  max=14.18s  p(90)=14.17s  p(95)=14.18s 
-     ws_sessions...........: 64      4.510465/s
+running (16.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (17.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (18.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (19.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (20.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (21.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (22.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (23.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (24.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (25.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (26.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (27.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (28.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (29.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (30.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (31.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (32.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (33.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (34.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (35.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+time="2025-09-30T19:12:11+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
 
 
-running (14.2s), 00/64 VUs, 64 complete and 0 interrupted iterations
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 64      min=64          max=64
+    vus_max............................: 64      min=64          max=64
+
+    NETWORK
+    data_received......................: 528 kB  15 kB/s
+    data_sent..........................: 61 MB   1.7 MB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=35.27ms min=14.35ms med=37.73ms max=38.36ms p(90)=38.02ms p(95)=38.05ms
+    ws_msgs_received...................: 81346   2322.107672/s
+    ws_msgs_sent.......................: 6099556 174118.282192/s
+    ws_sessions........................: 64      1.826948/s
+
+
+
+
+running (35.0s), 00/64 VUs, 0 complete and 64 interrupted iterations
 default ✓ [ 100% ] 64 VUs  5s

--- a/results/vus-64/uwebsocket-js/binary-sync.txt
+++ b/results/vus-64/uwebsocket-js/binary-sync.txt
@@ -1,16 +1,16 @@
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ./benchmarks/binary-sync.js
-     output: -
+     execution: local
+        script: ./benchmarks/binary-sync.js
+        output: -
 
-  scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
-           * default: 64 looping VUs for 5s (gracefulStop: 30s)
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
 
 
 running (01.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
@@ -26,12 +26,12 @@ running (04.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default   [  80% ] 64 VUs  4.0s/5s
 
 running (05.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [ 100% ] 64 VUs  5.0s/5s
+default ↓ [ 100% ] 64 VUs  5s
 
 running (06.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (07.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+running (07.3s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
 running (08.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
@@ -117,17 +117,26 @@ default ↓ [ 100% ] 64 VUs  5s
 
 running (35.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
+time="2025-09-30T19:11:29+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
 
-     ✓ status is 101
 
-     data_received......: 16 MB   453 kB/s
-     data_sent..........: 26 MB   754 kB/s
-     vus................: 64      min=64         max=64
-     vus_max............: 64      min=64         max=64
-     ws_connecting......: avg=23.09ms min=2.79ms med=6.83ms max=47.54ms p(90)=46.81ms p(95)=46.9ms
-     ws_msgs_received...: 2638451 75384.902691/s
-     ws_msgs_sent.......: 2638514 75386.702705/s
-     ws_sessions........: 64      1.828586/s
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 64     min=64         max=64
+    vus_max............................: 64     min=64         max=64
+
+    NETWORK
+    data_received......................: 4.0 MB 115 kB/s
+    data_sent..........................: 6.7 MB 192 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=21.8ms min=4.77ms med=27.16ms max=29.41ms p(90)=29.19ms p(95)=29.25ms
+    ws_msgs_received...................: 670318 19150.754963/s
+    ws_msgs_sent.......................: 670381 19152.554852/s
+    ws_sessions........................: 64     1.828458/s
+
+
 
 
 running (35.0s), 00/64 VUs, 0 complete and 64 interrupted iterations

--- a/results/vus-64/uwebsocket-js/connection.txt
+++ b/results/vus-64/uwebsocket-js/connection.txt
@@ -1,46 +1,59 @@
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ./benchmarks/connection.js
-     output: -
+     execution: local
+        script: ./benchmarks/connection.js
+        output: -
 
-  scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
-           * default: 64 looping VUs for 5s (gracefulStop: 30s)
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
 
 
-running (01.0s), 64/64 VUs, 10328 complete and 0 interrupted iterations
+running (01.0s), 64/64 VUs, 6047 complete and 0 interrupted iterations
 default   [  20% ] 64 VUs  1.0s/5s
 
-running (02.0s), 64/64 VUs, 21938 complete and 0 interrupted iterations
+running (02.0s), 64/64 VUs, 13190 complete and 0 interrupted iterations
 default   [  40% ] 64 VUs  2.0s/5s
 
-running (03.0s), 64/64 VUs, 34494 complete and 0 interrupted iterations
+running (03.0s), 64/64 VUs, 19475 complete and 0 interrupted iterations
 default   [  60% ] 64 VUs  3.0s/5s
 
-running (04.0s), 64/64 VUs, 46789 complete and 0 interrupted iterations
+running (04.0s), 64/64 VUs, 24834 complete and 0 interrupted iterations
 default   [  80% ] 64 VUs  4.0s/5s
 
-running (05.0s), 64/64 VUs, 59376 complete and 0 interrupted iterations
+running (05.0s), 64/64 VUs, 30382 complete and 0 interrupted iterations
 default   [ 100% ] 64 VUs  5.0s/5s
 
-     ✓ status is 101
 
-     checks................: 100.00% ✓ 59450        ✗ 0   
-     data_received.........: 11 MB   2.2 MB/s
-     data_sent.............: 13 MB   2.5 MB/s
-     iteration_duration....: avg=5.37ms min=830.4µs  med=4.9ms  max=58.95ms p(90)=7.71ms p(95)=8.95ms
-     iterations............: 59450   11882.529466/s
-     vus...................: 64      min=64         max=64
-     vus_max...............: 64      min=64         max=64
-     ws_connecting.........: avg=5.27ms min=682.24µs med=4.81ms max=58.78ms p(90)=7.58ms p(95)=8.8ms 
-     ws_session_duration...: avg=5.33ms min=796.58µs med=4.87ms max=58.88ms p(90)=7.66ms p(95)=8.89ms
-     ws_sessions...........: 59450   11882.529466/s
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 30488   6091.133653/s
+    checks_succeeded...................: 100.00% 30488 out of 30488
+    checks_failed......................: 0.00%   0 out of 30488
+
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=10.49ms min=590.75µs med=9.77ms max=57.78ms p(90)=14.3ms  p(95)=17.9ms 
+    iterations...............................: 30488  6091.133653/s
+    vus......................................: 64     min=64        max=64
+    vus_max..................................: 64     min=64        max=64
+
+    NETWORK
+    data_received............................: 5.6 MB 1.1 MB/s
+    data_sent................................: 6.1 MB 1.2 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=10.43ms min=556.91µs med=9.71ms max=57.73ms p(90)=14.24ms p(95)=17.85ms
+    ws_session_duration......................: avg=10.47ms min=579.87µs med=9.74ms max=57.76ms p(90)=14.27ms p(95)=17.87ms
+    ws_sessions..............................: 30488  6091.133653/s
 
 
-running (05.0s), 00/64 VUs, 59450 complete and 0 interrupted iterations
+
+
+running (05.0s), 00/64 VUs, 30488 complete and 0 interrupted iterations
 default ✓ [ 100% ] 64 VUs  5s

--- a/results/vus-64/uwebsocket-js/json-async.txt
+++ b/results/vus-64/uwebsocket-js/json-async.txt
@@ -1,32 +1,32 @@
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ./benchmarks/json-async.js
-     output: -
+     execution: local
+        script: ./benchmarks/json-async.js
+        output: -
 
-  scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
-           * default: 64 looping VUs for 5s (gracefulStop: 30s)
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
 
 
 running (01.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  19% ] 64 VUs  1.0s/5s
+default   [  20% ] 64 VUs  1.0s/5s
 
 running (02.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  39% ] 64 VUs  2.0s/5s
+default   [  40% ] 64 VUs  2.0s/5s
 
-running (03.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  59% ] 64 VUs  3.0s/5s
+running (03.4s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [  68% ] 64 VUs  3.4s/5s
 
 running (04.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  79% ] 64 VUs  4.0s/5s
+default   [  80% ] 64 VUs  4.0s/5s
 
 running (05.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
-default   [  99% ] 64 VUs  5.0s/5s
+default   [ 100% ] 64 VUs  5s
 
 running (06.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
@@ -43,26 +43,100 @@ default ↓ [ 100% ] 64 VUs  5s
 running (10.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-running (11.0s), 40/64 VUs, 24 complete and 0 interrupted iterations
+running (11.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
 
-     ✓ expected ${this} to be a number
-     ✓ expected ${this} to equal +0
-     ✓ status is 101
+running (12.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
 
-     checks................: 100.00% ✓ 192           ✗ 0   
-     data_received.........: 115 MB  10 MB/s
-     data_sent.............: 140 MB  12 MB/s
-     iteration_duration....: avg=11.01s  min=10.19s med=11.08s  max=11.35s  p(90)=11.32s  p(95)=11.34s 
-     iterations............: 64      5.634605/s
-     vus...................: 40      min=40          max=64
-     vus_max...............: 64      min=64          max=64
-     ws_connecting.........: avg=73.85ms min=1.7ms  med=71.58ms max=97.94ms p(90)=97.73ms p(95)=97.81ms
-     ws_msgs_received......: 6400000 563460.469109/s
-     ws_msgs_sent..........: 6400000 563460.469109/s
-     ws_session_duration...: avg=11.01s  min=10.19s med=11.08s  max=11.35s  p(90)=11.32s  p(95)=11.34s 
-     ws_sessions...........: 64      5.634605/s
+running (13.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (14.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (15.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (16.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (17.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (18.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (19.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (20.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (21.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (22.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (23.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (24.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (25.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (26.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (27.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (28.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (29.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (30.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (31.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (32.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (33.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (34.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (35.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+time="2025-09-30T19:10:47+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
 
 
-running (11.4s), 00/64 VUs, 64 complete and 0 interrupted iterations
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus..........................: 64      min=64          max=64
+    vus_max......................: 64      min=64          max=64
+
+    NETWORK
+    data_received................: 12 kB   335 B/s
+    data_sent....................: 111 MB  3.2 MB/s
+
+    WEBSOCKET
+    ws_connecting................: avg=53.56ms min=5.18ms med=65.96ms max=74.17ms p(90)=73.86ms p(95)=73.97ms
+    ws_msgs_sent.................: 5074335 144933.735039/s
+    ws_sessions..................: 64      1.827975/s
+
+
+
+
+running (35.0s), 00/64 VUs, 0 complete and 64 interrupted iterations
 default ✓ [ 100% ] 64 VUs  5s

--- a/results/vus-64/uwebsocket-js/json-sync.txt
+++ b/results/vus-64/uwebsocket-js/json-sync.txt
@@ -1,16 +1,16 @@
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ./benchmarks/json-sync.js
-     output: -
+     execution: local
+        script: ./benchmarks/json-sync.js
+        output: -
 
-  scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
-           * default: 64 looping VUs for 5s (gracefulStop: 30s)
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
 
 
 running (01.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
@@ -117,17 +117,26 @@ default ↓ [ 100% ] 64 VUs  5s
 
 running (35.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
+time="2025-09-30T19:10:05+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
 
-     ✓ status is 101
 
-     data_received......: 45 MB   1.3 MB/s
-     data_sent..........: 56 MB   1.6 MB/s
-     vus................: 64      min=64         max=64
-     vus_max............: 64      min=64         max=64
-     ws_connecting......: avg=16.46ms min=2.47ms med=3.76ms max=63.34ms p(90)=63.1ms p(95)=63.14ms
-     ws_msgs_received...: 2559921 73137.835789/s
-     ws_msgs_sent.......: 2559985 73139.664291/s
-     ws_sessions........: 64      1.828502/s
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 64     min=64         max=64
+    vus_max............................: 64     min=64         max=64
+
+    NETWORK
+    data_received......................: 12 MB  348 kB/s
+    data_sent..........................: 15 MB  429 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=23.22ms min=6.51ms med=22.36ms max=32.82ms p(90)=30.9ms p(95)=31.43ms
+    ws_msgs_received...................: 714787 20421.567327/s
+    ws_msgs_sent.......................: 714850 20423.367246/s
+    ws_sessions........................: 64     1.828489/s
+
+
 
 
 running (35.0s), 00/64 VUs, 0 complete and 64 interrupted iterations

--- a/results/vus-64/uwebsocket-js/plain-sync.txt
+++ b/results/vus-64/uwebsocket-js/plain-sync.txt
@@ -1,16 +1,16 @@
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ./benchmarks/plain-sync.js
-     output: -
+     execution: local
+        script: ./benchmarks/plain-sync.js
+        output: -
 
-  scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
-           * default: 64 looping VUs for 5s (gracefulStop: 30s)
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
 
 
 running (01.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
@@ -117,17 +117,26 @@ default ↓ [ 100% ] 64 VUs  5s
 
 running (35.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
 default ↓ [ 100% ] 64 VUs  5s
+time="2025-09-30T19:09:23+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
 
-     ✓ status is 101
 
-     data_received......: 42 MB   1.2 MB/s
-     data_sent..........: 53 MB   1.5 MB/s
-     vus................: 64      min=64         max=64
-     vus_max............: 64      min=64         max=64
-     ws_connecting......: avg=52.39ms min=1.21ms med=60.19ms max=61.01ms p(90)=60.51ms p(95)=60.8ms
-     ws_msgs_received...: 2823783 80674.607156/s
-     ws_msgs_sent.......: 2823847 80676.435616/s
-     ws_sessions........: 64      1.82846/s
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 64     min=64         max=64
+    vus_max............................: 64     min=64         max=64
+
+    NETWORK
+    data_received......................: 12 MB  350 kB/s
+    data_sent..........................: 16 MB  449 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=15.12ms min=5.9ms med=20.12ms max=22.6ms p(90)=21.51ms p(95)=21.89ms
+    ws_msgs_received...................: 863150 24660.507678/s
+    ws_msgs_sent.......................: 863214 24662.336181/s
+    ws_sessions........................: 64     1.828503/s
+
+
 
 
 running (35.0s), 00/64 VUs, 0 complete and 64 interrupted iterations

--- a/results/vus-64/websocketpp/binary-async.txt
+++ b/results/vus-64/websocketpp/binary-async.txt
@@ -1,0 +1,150 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/binary-async.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 64 VUs  1.0s/5s
+
+running (02.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 64 VUs  2.0s/5s
+
+running (03.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 64 VUs  3.0s/5s
+
+running (04.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 64 VUs  4.0s/5s
+
+running (05.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 64 VUs  5.0s/5s
+
+running (06.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (07.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (08.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (09.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (10.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (11.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (12.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (13.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (14.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (15.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (16.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (17.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (18.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (19.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (20.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (21.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (22.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (23.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (24.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (25.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (26.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (27.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (28.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (29.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (30.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (31.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (32.0s), 63/64 VUs, 1 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (33.0s), 56/64 VUs, 8 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (34.0s), 36/64 VUs, 28 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 192     5.515013/s
+    checks_succeeded...................: 100.00% 192 out of 192
+    checks_failed......................: 0.00%   0 out of 192
+
+    ✓ expected ${this} to be a number
+    ✓ expected ${this} to equal +0
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=34s     min=31.64s med=34.22s  max=34.81s  p(90)=34.75s  p(95)=34.76s 
+    iterations...............................: 64      1.838338/s
+    vus......................................: 36      min=36          max=64
+    vus_max..................................: 64      min=64          max=64
+
+    NETWORK
+    data_received............................: 38 MB   1.1 MB/s
+    data_sent................................: 64 MB   1.8 MB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=32.21ms min=5.66ms med=38.58ms max=40.56ms p(90)=40.04ms p(95)=40.13ms
+    ws_msgs_received.........................: 6400000 183833.751785/s
+    ws_msgs_sent.............................: 6400000 183833.751785/s
+    ws_session_duration......................: avg=34s     min=31.64s med=34.22s  max=34.81s  p(90)=34.75s  p(95)=34.76s 
+    ws_sessions..............................: 64      1.838338/s
+
+
+
+
+running (34.8s), 00/64 VUs, 64 complete and 0 interrupted iterations
+default ✓ [ 100% ] 64 VUs  5s

--- a/results/vus-64/websocketpp/binary-sync.txt
+++ b/results/vus-64/websocketpp/binary-sync.txt
@@ -1,0 +1,143 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/binary-sync.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 64 VUs  1.0s/5s
+
+running (02.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 64 VUs  2.0s/5s
+
+running (03.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 64 VUs  3.0s/5s
+
+running (04.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 64 VUs  4.0s/5s
+
+running (05.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 64 VUs  5.0s/5s
+
+running (06.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (07.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (08.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (09.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (10.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (11.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (12.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (13.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (14.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (15.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (16.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (17.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (18.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (19.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (20.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (21.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (22.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (23.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (24.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (25.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (26.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (27.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (28.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (29.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (30.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (31.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (32.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (33.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (34.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (35.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+time="2025-09-30T19:15:38+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
+
+
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 64      min=64         max=64
+    vus_max............................: 64      min=64         max=64
+
+    NETWORK
+    data_received......................: 6.2 MB  177 kB/s
+    data_sent..........................: 10 MB   295 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=13.99ms min=4.21ms med=14.48ms max=20.19ms p(90)=18.46ms p(95)=18.55ms
+    ws_msgs_received...................: 1029467 29412.149564/s
+    ws_msgs_sent.......................: 1029531 29413.978061/s
+    ws_sessions........................: 64      1.828497/s
+
+
+
+
+running (35.0s), 00/64 VUs, 0 complete and 64 interrupted iterations
+default ✓ [ 100% ] 64 VUs  5s

--- a/results/vus-64/websocketpp/connection.txt
+++ b/results/vus-64/websocketpp/connection.txt
@@ -1,0 +1,59 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/connection.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 64/64 VUs, 6707 complete and 0 interrupted iterations
+default   [  20% ] 64 VUs  1.0s/5s
+
+running (02.0s), 64/64 VUs, 12724 complete and 0 interrupted iterations
+default   [  40% ] 64 VUs  2.0s/5s
+
+running (03.0s), 64/64 VUs, 18885 complete and 0 interrupted iterations
+default   [  60% ] 64 VUs  3.0s/5s
+
+running (04.0s), 64/64 VUs, 20267 complete and 0 interrupted iterations
+default   [  82% ] 64 VUs  4.1s/5s
+
+running (05.1s), 64/64 VUs, 20539 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......................: 20603   3886.332645/s
+    checks_succeeded...................: 100.00% 20603 out of 20603
+    checks_failed......................: 0.00%   0 out of 20603
+
+    ✓ status is 101
+
+    EXECUTION
+    iteration_duration.......................: avg=16.13ms min=1.2ms  med=10.1ms  max=562.28ms p(90)=18.66ms p(95)=31.88ms
+    iterations...............................: 20603  3886.332645/s
+    vus......................................: 64     min=64        max=64
+    vus_max..................................: 64     min=64        max=64
+
+    NETWORK
+    data_received............................: 3.2 MB 606 kB/s
+    data_sent................................: 4.1 MB 781 kB/s
+
+    WEBSOCKET
+    ws_connecting............................: avg=15.91ms min=1.15ms med=10.06ms max=488.23ms p(90)=18.59ms p(95)=31.8ms 
+    ws_session_duration......................: avg=16.09ms min=1.18ms med=10.09ms max=562.15ms p(90)=18.62ms p(95)=31.85ms
+    ws_sessions..............................: 20603  3886.332645/s
+
+
+
+
+running (05.3s), 00/64 VUs, 20603 complete and 0 interrupted iterations
+default ✓ [ 100% ] 64 VUs  5s

--- a/results/vus-64/websocketpp/json-sync.txt
+++ b/results/vus-64/websocketpp/json-sync.txt
@@ -1,0 +1,143 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/json-sync.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 64 VUs  1.0s/5s
+
+running (02.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 64 VUs  2.0s/5s
+
+running (03.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 64 VUs  3.0s/5s
+
+running (04.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 64 VUs  4.0s/5s
+
+running (05.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 64 VUs  5.0s/5s
+
+running (06.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (07.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (08.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (09.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (10.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (11.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (12.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (13.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (14.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (15.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (16.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (17.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (18.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (19.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (20.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (21.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (22.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (23.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (24.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (25.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (26.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (27.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (28.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (29.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (30.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (31.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (32.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (33.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (34.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (35.0s), 24/64 VUs, 0 complete and 41 interrupted iterations
+default ✓ [ 100% ] 64 VUs  5s
+time="2025-09-30T19:14:06+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
+
+
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 64      min=64         max=64
+    vus_max............................: 64      min=64         max=64
+
+    NETWORK
+    data_received......................: 19 MB   529 kB/s
+    data_sent..........................: 23 MB   651 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=14.96ms min=5.68ms med=16.34ms max=19.15ms p(90)=18.59ms p(95)=18.63ms
+    ws_msgs_received...................: 1067427 30474.573375/s
+    ws_msgs_sent.......................: 1067488 30476.314898/s
+    ws_sessions........................: 64      1.827172/s
+
+
+
+
+running (35.0s), 00/64 VUs, 0 complete and 64 interrupted iterations
+default ✓ [ 100% ] 64 VUs  5s

--- a/results/vus-64/websocketpp/plain-sync.txt
+++ b/results/vus-64/websocketpp/plain-sync.txt
@@ -1,0 +1,146 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: ./benchmarks/plain-sync.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 64 max VUs, 35s max duration (incl. graceful stop):
+              * default: 64 looping VUs for 5s (gracefulStop: 30s)
+
+
+running (01.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 64 VUs  1.0s/5s
+
+running (01.7s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [  33% ] 64 VUs  1.7s/5s
+
+running (02.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 64 VUs  2.0s/5s
+
+running (03.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [  60% ] 64 VUs  3.0s/5s
+
+running (04.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [  80% ] 64 VUs  4.0s/5s
+
+running (05.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default   [ 100% ] 64 VUs  5.0s/5s
+
+running (06.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (07.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (08.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (09.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (10.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (11.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (12.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (13.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (14.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (15.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (16.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (17.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (18.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (19.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (20.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (21.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (22.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (23.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (24.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (25.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (26.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (27.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (28.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (29.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (30.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (31.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (32.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (33.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (34.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+
+running (35.0s), 64/64 VUs, 0 complete and 0 interrupted iterations
+default ↓ [ 100% ] 64 VUs  5s
+time="2025-09-30T19:13:14+07:00" level=warning msg="No script iterations fully finished, consider making the test duration longer"
+
+
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    vus................................: 64      min=64         max=64
+    vus_max............................: 64      min=64         max=64
+
+    NETWORK
+    data_received......................: 14 MB   409 kB/s
+    data_sent..........................: 18 MB   524 kB/s
+
+    WEBSOCKET
+    ws_connecting......................: avg=14.15ms min=6.76ms med=14.84ms max=17.2ms p(90)=16.3ms p(95)=16.68ms
+    ws_msgs_received...................: 1001620 28616.046379/s
+    ws_msgs_sent.......................: 1001684 28617.874844/s
+    ws_sessions........................: 64      1.828465/s
+
+
+
+
+running (35.0s), 00/64 VUs, 0 complete and 64 interrupted iterations
+default ✓ [ 100% ] 64 VUs  5s

--- a/websocket_benchmark.sh
+++ b/websocket_benchmark.sh
@@ -1,0 +1,386 @@
+#!/bin/bash
+
+# Comprehensive WebSocket Benchmark Suite
+# Combines benchmarking, result extraction, and parsing in one script
+# Usage: ./websocket_benchmark.sh [benchmark|extract|both]
+
+set -e
+
+# Configuration
+FRAMEWORKS=(
+    "tokio-tungstenite"
+    "fasthttp-websocket" 
+    "gorilla-websocket"
+    "uwebsocket-js"
+    "websocketpp"
+    "sib"
+)
+
+BUN_FRAMEWORKS=(
+    "bun-websocket-plain"
+    "bun-websocket-json"
+    "bun-websocket-binary"
+)
+
+TESTS=(
+    "connection"
+    "plain-sync"
+    "plain-async"
+    "json-sync"
+    "json-async"
+    "binary-sync"
+    "binary-async"
+)
+
+RESULTS_DIR="./results/vus-16"
+VUS=16
+DURATION="5s"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_status() {
+    local color=$1
+    local message=$2
+    echo -e "${color}${message}${NC}"
+}
+
+# Function to run benchmark for a framework and test
+run_benchmark() {
+    local framework=$1
+    local test=$2
+    local output_file="$RESULTS_DIR/$framework/$test.txt"
+    
+    # Create framework directory
+    mkdir -p "$RESULTS_DIR/$framework"
+    
+    print_status "$BLUE" "Testing $framework with $test..."
+    
+    # Stop any running containers
+    docker compose down > /dev/null 2>&1 || true
+    
+    # Start the framework
+    docker compose up -d "$framework" > /dev/null 2>&1
+    
+    # Wait for container to be ready
+    sleep 3
+    
+    # Run the benchmark
+    if k6 run --vus "$VUS" --duration "$DURATION" "./benchmarks/${test}.js" > "$output_file" 2>&1; then
+        print_status "$GREEN" "✓ $framework $test completed"
+    else
+        print_status "$RED" "✗ $framework $test failed"
+    fi
+    
+    # Stop the container
+    docker compose down > /dev/null 2>&1 || true
+    sleep 2
+}
+
+# Function to run all benchmarks
+run_all_benchmarks() {
+    print_status "$YELLOW" "=== Starting comprehensive WebSocket benchmarks ==="
+    echo "Frameworks: ${FRAMEWORKS[*]} + bun variants"
+    echo "Tests: ${TESTS[*]}"
+    echo "Configuration: $VUS VUs, $DURATION duration, 2 CPU cores, 1GB memory"
+    echo ""
+
+    # Create results directory
+    mkdir -p "$RESULTS_DIR"
+
+    # Test regular frameworks
+    for framework in "${FRAMEWORKS[@]}"; do
+        echo ""
+        print_status "$YELLOW" "=== Testing $framework ==="
+        
+        for test in "${TESTS[@]}"; do
+            run_benchmark "$framework" "$test"
+        done
+    done
+
+    # Special handling for Bun WebSocket (separate containers for different endpoints)
+    echo ""
+    print_status "$YELLOW" "=== Testing bun-websocket ==="
+
+    # Create bun-websocket results directory
+    mkdir -p "$RESULTS_DIR/bun-websocket"
+
+    # Connection test (can use any bun variant)
+    print_status "$BLUE" "Testing bun-websocket with connection..."
+    docker compose down > /dev/null 2>&1 || true
+    docker compose up -d bun-websocket-plain > /dev/null 2>&1
+    sleep 3
+    if k6 run --vus "$VUS" --duration "$DURATION" "./benchmarks/connection.js" > "$RESULTS_DIR/bun-websocket/connection.txt" 2>&1; then
+        print_status "$GREEN" "✓ bun-websocket connection completed"
+    else
+        print_status "$RED" "✗ bun-websocket connection failed"
+    fi
+    docker compose down > /dev/null 2>&1 || true
+
+    # Plain tests
+    for test in "plain-sync" "plain-async"; do
+        print_status "$BLUE" "Testing bun-websocket with $test..."
+        docker compose up -d bun-websocket-plain > /dev/null 2>&1
+        sleep 3
+        if k6 run --vus "$VUS" --duration "$DURATION" "./benchmarks/${test}.js" > "$RESULTS_DIR/bun-websocket/${test}.txt" 2>&1; then
+            print_status "$GREEN" "✓ bun-websocket $test completed"
+        else
+            print_status "$RED" "✗ bun-websocket $test failed"
+        fi
+        docker compose down > /dev/null 2>&1 || true
+        sleep 2
+    done
+
+    # JSON tests
+    for test in "json-sync" "json-async"; do
+        print_status "$BLUE" "Testing bun-websocket with $test..."
+        docker compose up -d bun-websocket-json > /dev/null 2>&1
+        sleep 3
+        if k6 run --vus "$VUS" --duration "$DURATION" "./benchmarks/${test}.js" > "$RESULTS_DIR/bun-websocket/${test}.txt" 2>&1; then
+            print_status "$GREEN" "✓ bun-websocket $test completed"
+        else
+            print_status "$RED" "✗ bun-websocket $test failed"
+        fi
+        docker compose down > /dev/null 2>&1 || true
+        sleep 2
+    done
+
+    # Binary tests
+    for test in "binary-sync" "binary-async"; do
+        print_status "$BLUE" "Testing bun-websocket with $test..."
+        docker compose up -d bun-websocket-binary > /dev/null 2>&1
+        sleep 3
+        if k6 run --vus "$VUS" --duration "$DURATION" "./benchmarks/${test}.js" > "$RESULTS_DIR/bun-websocket/${test}.txt" 2>&1; then
+            print_status "$GREEN" "✓ bun-websocket $test completed"
+        else
+            print_status "$RED" "✗ bun-websocket $test failed"
+        fi
+        docker compose down > /dev/null 2>&1 || true
+        sleep 2
+    done
+
+    echo ""
+    print_status "$GREEN" "=== Benchmarking completed! ==="
+    echo "Results saved in $RESULTS_DIR/"
+}
+
+# Function to extract metric value from k6 results
+extract_metric() {
+    local file="$1"
+    local metric_name="$2"
+    
+    if [[ -f "$file" ]]; then
+        # Extract the rate (third column) after the metric name
+        grep "^    $metric_name" "$file" | awk '{print $3}' | head -1
+    else
+        echo "N/A"
+    fi
+}
+
+# Function to extract ws_connecting details
+extract_connecting_details() {
+    local file="$1"
+    
+    if [[ -f "$file" ]]; then
+        # Extract everything after ws_connecting.:
+        grep "^    ws_connecting" "$file" | sed 's/^.*ws_connecting.*: //' | head -1
+    else
+        echo "N/A"
+    fi
+}
+
+# Function to sort frameworks by performance
+sort_frameworks_by_metric() {
+    local frameworks_list="$1"
+    local metric_type=$2
+    local test_file=$3
+    
+    local temp_file=$(mktemp)
+    
+    # Extract metrics and create sortable list
+    for fw in $frameworks_list; do
+        local file="$RESULTS_DIR/$fw/$test_file"
+        local value=$(extract_metric "$file" "$metric_type")
+        
+        # Convert to number for sorting (remove /s and other non-numeric chars)
+        local numeric_value=$(echo "$value" | sed 's/[^0-9.]//g')
+        
+        if [[ "$numeric_value" =~ ^[0-9]*\.?[0-9]+$ ]]; then
+            echo "$numeric_value $fw" >> "$temp_file"
+        else
+            echo "0 $fw" >> "$temp_file"
+        fi
+    done
+    
+    # Sort by numeric value (descending) and extract framework names
+    sort -nr "$temp_file" | awk '{print $2}'
+    rm "$temp_file"
+}
+
+# Function to extract and display results
+extract_results() {
+    print_status "$YELLOW" "Parsing WebSocket Benchmark Results ($VUS VUs, $DURATION duration, 2 CPU cores)"
+    echo "==============================================================="
+    echo
+
+    # Get list of frameworks that have results
+    local frameworks=()
+    for dir in "$RESULTS_DIR"/*/; do
+        if [[ -d "$dir" ]]; then
+            fw=$(basename "$dir")
+            frameworks+=("$fw")
+        fi
+    done
+
+    if [[ ${#frameworks[@]} -eq 0 ]]; then
+        print_status "$RED" "No benchmark results found in $RESULTS_DIR"
+        return 1
+    fi
+
+    print_status "$BLUE" "Available frameworks: ${frameworks[*]}"
+    echo
+
+    # Connection Results (sorted by performance)
+    echo "### Connection Method $VUS VUs Result"
+    echo
+    echo "| Framework | ws_sessions | ws_connecting |"
+    echo "|-----------|-------------|---------------|"
+
+    # Sort frameworks by connection performance
+    local sorted_frameworks=$(sort_frameworks_by_metric "${frameworks[*]}" "ws_sessions" "connection.txt")
+
+    for fw in $sorted_frameworks; do
+        local file="$RESULTS_DIR/$fw/connection.txt"
+        local sessions=$(extract_metric "$file" "ws_sessions")
+        local connecting=$(extract_connecting_details "$file")
+        echo "| $fw | $sessions | $connecting |"
+    done
+
+    echo
+
+    # JSON Sync Results (sorted by performance)
+    echo "### JSON Sync Method $VUS VUs Result"
+    echo
+    echo "| Framework | ws_msgs_received |"
+    echo "|-----------|------------------|"
+
+    local sorted_frameworks=$(sort_frameworks_by_metric "${frameworks[*]}" "ws_msgs_received" "json-sync.txt")
+
+    for fw in $sorted_frameworks; do
+        local file="$RESULTS_DIR/$fw/json-sync.txt"
+        local msgs=$(extract_metric "$file" "ws_msgs_received")
+        echo "| $fw | $msgs |"
+    done
+
+    echo
+
+    # JSON Async Results (sorted by performance)
+    echo "### JSON Async Method $VUS VUs Result" 
+    echo
+    echo "| Framework | ws_msgs_received |"
+    echo "|-----------|------------------|"
+
+    local sorted_frameworks=$(sort_frameworks_by_metric "${frameworks[*]}" "ws_msgs_received" "json-async.txt")
+
+    for fw in $sorted_frameworks; do
+        local file="$RESULTS_DIR/$fw/json-async.txt"
+        local msgs=$(extract_metric "$file" "ws_msgs_received")
+        echo "| $fw | $msgs |"
+    done
+
+    echo
+
+    # Binary Sync Results (sorted by performance)
+    echo "### Binary Sync Method $VUS VUs Result"
+    echo
+    echo "| Framework | ws_msgs_received |"
+    echo "|-----------|------------------|"
+
+    local sorted_frameworks=$(sort_frameworks_by_metric "${frameworks[*]}" "ws_msgs_received" "binary-sync.txt")
+
+    for fw in $sorted_frameworks; do
+        local file="$RESULTS_DIR/$fw/binary-sync.txt"
+        local msgs=$(extract_metric "$file" "ws_msgs_received")
+        echo "| $fw | $msgs |"
+    done
+
+    echo
+
+    # Binary Async Results (sorted by performance)
+    echo "### Binary Async Method $VUS VUs Result"
+    echo
+    echo "| Framework | ws_msgs_received |"
+    echo "|-----------|------------------|"
+
+    local sorted_frameworks=$(sort_frameworks_by_metric "${frameworks[*]}" "ws_msgs_received" "binary-async.txt")
+
+    for fw in $sorted_frameworks; do
+        local file="$RESULTS_DIR/$fw/binary-async.txt"  
+        local msgs=$(extract_metric "$file" "ws_msgs_received")
+        echo "| $fw | $msgs |"
+    done
+
+    echo
+    print_status "$GREEN" "Results extraction completed!"
+}
+
+# Function to display usage
+show_usage() {
+    echo "WebSocket Benchmark Suite - Comprehensive testing and analysis tool"
+    echo ""
+    echo "Usage: $0 [benchmark|extract|both|help]"
+    echo ""
+    echo "Commands:"
+    echo "  benchmark  - Run benchmarks for all frameworks"
+    echo "  extract    - Extract and display results from existing benchmark data"
+    echo "  both       - Run benchmarks and then extract results (default)"
+    echo "  help       - Show this help message"
+    echo ""
+    echo "Configuration:"
+    echo "  VUs: $VUS"
+    echo "  Duration: $DURATION"
+    echo "  Results directory: $RESULTS_DIR"
+    echo ""
+    echo "Examples:"
+    echo "  $0                 # Run full benchmark suite and extract results"
+    echo "  $0 benchmark       # Only run benchmarks"
+    echo "  $0 extract         # Only extract results from existing data"
+}
+
+# Main script logic
+main() {
+    local command=${1:-both}
+    
+    case "$command" in
+        "benchmark")
+            run_all_benchmarks
+            ;;
+        "extract")
+            extract_results
+            ;;
+        "both")
+            run_all_benchmarks
+            echo ""
+            extract_results
+            ;;
+        "help"|"-h"|"--help")
+            show_usage
+            ;;
+        *)
+            echo "Unknown command: $command"
+            echo ""
+            show_usage
+            exit 1
+            ;;
+    esac
+}
+
+# Check if script is being run directly
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi


### PR DESCRIPTION
Major Features:
- Add websocket_benchmark.sh unified script for automated testing across all frameworks
- Add websocketpp (C++) and SIB (Rust) WebSocket framework support
- Restructure Makefile with intuitive targets (benchmark-all, benchmark-comprehensive)
- Add 16 VUs benchmark configuration for low-resource testing

Performance Improvements:
- Reduce CPU limit from 4.0 to 2.0 cores for M3 Mac compatibility
- Update VU configuration from 128 to 16 for individual tests
- Add automated result extraction and performance ranking

New Capabilities:
- Comprehensive benchmark automation across 6 frameworks
- Performance-sorted result tables with detailed metrics
- Color-coded output and error handling
- Support for both individual and comprehensive testing modes

Updated Documentation:
- Enhanced README with detailed usage instructions
- Updated benchmark results for 16 and 64 VUs configurations
- Added direct script usage examples and make target descriptions

Breaking Changes:
- benchmark-all now runs comprehensive framework tests (was individual tests)
- Individual test functionality moved to benchmark-individual target
- Updated VU defaults from 128 to 16 for resource-constrained environments